### PR TITLE
fix for tests failing on windows machines

### DIFF
--- a/src/steps/add_new_ids.py
+++ b/src/steps/add_new_ids.py
@@ -74,7 +74,7 @@ class AddNewIds(TransformerMixin):
             self.add_new_ids(img_path)
 
         if os.path.exists(os.path.join(self.target_path, "source_paths.csv")):
-            with open(os.path.join(self.target_path, "source_paths.csv"), "w") as temp_file:
+            with open(os.path.join(self.target_path, "source_paths.csv"), "w", newline="") as temp_file:
                 writer = csv.writer(temp_file)
                 writer.writerows(list(self.paths_data))
 

--- a/src/steps/get_source_paths.py
+++ b/src/steps/get_source_paths.py
@@ -48,7 +48,7 @@ class GetSourcePaths(TransformerMixin):
         for img_path in tqdm(X):
             self.get_source_paths(img_path)
 
-        with open(os.path.join(self.target_path, "source_paths.csv"), "w") as temp_file:
+        with open(os.path.join(self.target_path, "source_paths.csv"), "w", newline="") as temp_file:
             writer = csv.writer(temp_file)
             paths_data = np.transpose(np.vstack([list(self.paths_dict.keys()), list(self.paths_dict.values())]), (1, 0))
             writer.writerows(list(paths_data))


### PR DESCRIPTION
Identified the problem and fixed steps in pipelines for windows machines. Tests are now passing. This bug was windows machines specific. tl:dr additional empty rows in csv files were created because of default end file formatting on windows. 

https://stackoverflow.com/questions/3348460/csv-file-written-with-python-has-blank-lines-between-each-row