### PR TITLE
[Fix] Typo bug and code refactoring

### DIFF
--- a/src/pipelines/brain_tumor_classification.py
+++ b/src/pipelines/brain_tumor_classification.py
@@ -10,6 +10,7 @@ from base.pipeline import BasePipeline, PipelineArgs
 from base.selectors.img_selector import BaseImageSelector
 from base.selectors.mask_selector import BaseMaskSelector
 from config.dataset_config import DatasetArgs, brain_tumor_classification
+from constants import IMG_FOLDER_NAME
 from steps import (
     AddLabels,
     AddUmieIds,
@@ -113,7 +114,7 @@ class BrainTumorClassificationPipeline(BasePipeline):
     dataset_args: DatasetArgs = field(default_factory=lambda: brain_tumor_classification)
     pipeline_args: PipelineArgs = field(
         default_factory=lambda: PipelineArgs(
-            image_folder_name="Images",
+            image_folder_name=IMG_FOLDER_NAME,
             img_id_extractor=ImgIdExtractor(),
             study_id_extractor=StudyIdExtractor(),
             img_prefix="",

--- a/src/pipelines/brain_tumor_detection.py
+++ b/src/pipelines/brain_tumor_detection.py
@@ -8,6 +8,7 @@ from base.pipeline import BasePipeline, PipelineArgs
 from base.selectors.img_selector import BaseImageSelector
 from base.selectors.mask_selector import BaseMaskSelector
 from config.dataset_config import DatasetArgs, brain_tumor_detection
+from constants import IMG_FOLDER_NAME
 from steps import (
     AddLabels,
     AddUmieIds,
@@ -90,7 +91,7 @@ class BrainTumorDetectionPipeline(BasePipeline):
     dataset_args: DatasetArgs = field(default_factory=lambda: brain_tumor_detection)
     pipeline_args: PipelineArgs = field(
         default_factory=lambda: PipelineArgs(
-            image_folder_name="Images",
+            image_folder_name=IMG_FOLDER_NAME,
             img_prefix="",
             img_id_extractor=ImgIdExtractor(),
             study_id_extractor=StudyIdExtractor(),

--- a/testing/tests/test_knee_osteoarthritis.py
+++ b/testing/tests/test_knee_osteoarthritis.py
@@ -68,7 +68,7 @@ def test_knee_osteoarthritis_verify_jsonl_correct():
         current_jsonl = [json.loads(line) for line in file]
 
     if not DatasetTestingLibrary.verify_jsonl_identical(expected_jsonl, current_jsonl):
-        pytest.fail("Brain Tumor Progression pipeline created jsonl contents different than expected.")
+        pytest.fail("Knee Osteoarthritis pipeline created jsonl contents different than expected.")
 
 
 def test_clean_up_knee_osteoarthritis():


### PR DESCRIPTION
Issue: #102 

`brain_tumor_classification` | Fix
`brain_tumor_detection` | Fix
`test_knee_osteoarthritis.py` | Fix

In pipeline `brain_tumor_classification` I changed string on already defined variable  in `constants` file.
In pipeline `brain_tumor_detection` I changed string on already defined variable  in `constants` file.
In test file`test_knee_osteoarthritis.py`  was used wrong print message.
