### PR TITLE
[Enhancement] Optional data-quality, preprocessing, metadata, format, infra & export steps (Tasks 10–30, Themes D–I)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,40 @@ Due to the copyright restrictions of the source datasets, we can't share the fil
 
 To preprocess the dataset that is not among the above, search the preprocessing folder. It contains the reusable steps for changing imaging formats, extracting masks, creating file trees, etc. Go to the config file to check which masks and label encodings are available. Append new labels and mask encodings if needed.
 
+### Optional pipeline steps (data quality, preprocessing, metadata, formats, infra & export)
+
+Beyond the core conversion steps, the pipeline ships a set of **optional, opt-in** steps that plug
+into any `BasePipeline` via its `steps` tuple. They are **additive**: when not configured they are a
+no-op, and they never change UMIE ids, the `{uid}_{name}/{phase}/Images|Masks/` layout, or existing
+JSONL fields. Configuration is supplied per-pipeline through new sub-configs on `PipelineArgs`
+(`quality=`, `preprocessing=`, `metadata=`, `format_conversion=`, `export=`). Analysis steps write
+their findings to a `reports/` folder next to `Images`/`Masks`.
+
+| Step | Purpose | Config |
+|------|---------|--------|
+| `DetectDuplicates` | perceptual-hash duplicate / near-duplicate & cross-dataset overlap report | `quality` |
+| `DetectCorruptImages` | flag unreadable / truncated / blank / undersized images | `quality` |
+| `CheckMaskQuality` | mask↔image dim match, in-vocabulary colors, empty-mask report | `quality` |
+| `ValidateDicomMetadata` | verify required DICOM tags **before** conversion | `quality` |
+| `ApplyWindowing` | named CT HU window presets (lung/bone/brain/…) | `preprocessing` |
+| `ApplyClahe` | optional CLAHE contrast enhancement (images only) | `preprocessing` |
+| `NormalizeSpacing` | resample NIfTI volumes to a target voxel spacing | `preprocessing` |
+| `ResizeImages` | resize to a standard size (pad/crop/letterbox/stretch); masks nearest-neighbour | `preprocessing` |
+| `StandardizeBitDepth` | standardize 8/16-bit sources | `preprocessing` |
+| `AutocropBorders` | crop uniform black borders; mask cropped identically | `preprocessing` |
+| `ExtractDicomMetadata` | extract de-identified DICOM tags into the JSONL | `metadata` |
+| `CreateSplits` | reproducible **patient/study-level** train/val/test splits | `metadata` |
+| `AddProvenance` | additive license / source-attribution fields (`config/provenance.py`) | `metadata` |
+| `ConvertDicomSeg` | DICOM-SEG / RTSTRUCT → UMIE masks | `format_conversion` |
+| `ConvertBboxToMask` | COCO / YOLO / VOC bounding boxes → UMIE masks | `format_conversion` |
+| `MergeMasks` | merge single-structure masks into one multi-class mask | `format_conversion` |
+| `CreateManifest` | SHA-256 manifest of outputs + a `verify` mode | `export` |
+| `SkipProcessed` | incremental processing: skip already-converted files | `export` |
+| `ExportHuggingFace` | write an HF `datasets` Arrow dataset (with splits) + auto dataset card | `export` |
+
+Cross-cutting utilities: `utils/distribution_report.py` (cross-dataset label/modality/imbalance
+report from the JSONL) and `utils/parallel.py` (deterministic, order-preserving parallel map).
+
 Overall the dataset should have **882,774** images in **.png** format
 * **CT - 500k+**
 * **X-Ray - 250k+**

--- a/config/masks.py
+++ b/config/masks.py
@@ -123,3 +123,8 @@ Mass = Mask(
     radlex_id="RID3874",
     source_names={"ChestX-ray14": ["Mass"], "cmmd": ["mass"]},
 )
+
+# Registry of every defined mask, mirroring ``config/labels.py``'s ``all_labels``. Consumed by the
+# cross-dataset distribution report (Task 22) and the mask-quality check (Task 12); also fixes the
+# previously-missing ``config.masks.all_masks`` reference in ``utils/data_counter.py``.
+all_masks = [obj for name, obj in list(globals().items()) if isinstance(obj, Mask)]

--- a/config/provenance.py
+++ b/config/provenance.py
@@ -1,0 +1,131 @@
+"""Canonical license & source-attribution table for the integrated datasets (Task 23).
+
+This is the single source of truth consumed by:
+- the ``AddProvenance`` step (``src/steps/add_provenance.py``), which writes additive
+  ``license`` / ``source_dataset`` / ``source_citation`` fields into the JSONL records, and
+- the HuggingFace export (``src/steps/export_huggingface.py``) and dataset-card generation,
+  which surface the same machine-readable license + attribution.
+
+Keyed by ``DatasetArgs.dataset_name``. ``license`` uses an SPDX-style identifier where one
+exists, or a short human-readable string otherwise. Unknown entries fall back to
+``DEFAULT_PROVENANCE`` so the field is always populated (and flagged as ``unknown``).
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Provenance:
+    """License and source attribution for one integrated dataset."""
+
+    license: str  # SPDX identifier or short human-readable license string
+    source_dataset: str  # canonical name of the original source dataset
+    source_url: Optional[str] = None  # where the source dataset can be obtained
+    source_citation: Optional[str] = None  # short citation string to carry through to HF cards / docs
+    redistributable: Optional[bool] = None  # whether redistribution is permitted (None = unknown / check license)
+
+
+DEFAULT_PROVENANCE = Provenance(
+    license="unknown",
+    source_dataset="unknown",
+    redistributable=None,
+)
+
+# Best-effort table for the currently-integrated datasets. License strings should be verified
+# against each source's terms before redistribution; entries marked "unknown" need confirmation.
+PROVENANCE: dict[str, Provenance] = {
+    "kits23": Provenance(
+        license="CC-BY-NC-SA-4.0",
+        source_dataset="KiTS23 (Kidney Tumor Segmentation Challenge 2023)",
+        source_url="https://kits-challenge.org/kits23/",
+        redistributable=True,
+    ),
+    "coronahack": Provenance(
+        license="unknown",
+        source_dataset="CoronaHack Chest X-Ray Dataset",
+        source_url="https://www.kaggle.com/datasets/praveengovi/coronahack-chest-xraydataset",
+    ),
+    "alzheimers": Provenance(
+        license="unknown",
+        source_dataset="Alzheimer's MRI Dataset",
+        source_url="https://www.kaggle.com/datasets/sachinkumar413/alzheimer-mri-dataset",
+    ),
+    "brain_tumor_classification": Provenance(
+        license="unknown",
+        source_dataset="Brain Tumor Classification (MRI)",
+        source_url="https://www.kaggle.com/datasets/sartajbhuvaji/brain-tumor-classification-mri",
+    ),
+    "covid19_detection": Provenance(
+        license="unknown",
+        source_dataset="COVID-19 Chest X-ray detection",
+    ),
+    "finding_and_measuring_lungs": Provenance(
+        license="unknown",
+        source_dataset="Finding and Measuring Lungs in CT Data",
+        source_url="https://www.kaggle.com/datasets/kmader/finding-lungs-in-ct-data",
+    ),
+    "brain_with_intracranial_hemorrhage": Provenance(
+        license="CC-BY-4.0",
+        source_dataset="Computed Tomography Images for Intracranial Hemorrhage Detection",
+        source_url="https://physionet.org/content/ct-ich/",
+    ),
+    "lits": Provenance(
+        license="CC-BY-NC-ND-4.0",
+        source_dataset="LiTS - Liver Tumor Segmentation Challenge",
+        redistributable=False,
+    ),
+    "brain_tumor_detection": Provenance(
+        license="unknown",
+        source_dataset="Brain MRI Images for Brain Tumor Detection",
+    ),
+    "knee_osteoarthritis": Provenance(
+        license="unknown",
+        source_dataset="Knee Osteoarthritis Dataset with Severity Grading",
+    ),
+    "brain_tumor_progression": Provenance(
+        license="CC-BY-3.0",
+        source_dataset="Brain-Tumor-Progression (TCIA)",
+        source_url="https://www.cancerimagingarchive.net/collection/brain-tumor-progression/",
+        redistributable=True,
+    ),
+    "chest_xray14": Provenance(
+        license="No restriction (NIH public)",
+        source_dataset="NIH ChestX-ray14",
+        source_url="https://nihcc.app.box.com/v/ChestXray-NIHCC",
+        redistributable=True,
+    ),
+    "coca": Provenance(
+        license="Stanford AIMI (research use)",
+        source_dataset="COCA - Coronary Calcium and chest CTs",
+        source_url="https://stanfordaimi.azurewebsites.net/datasets/e8ca74dc-8dd4-4340-815a-60b41f6cb2aa",
+    ),
+    "brain_met_share": Provenance(
+        license="Stanford AIMI (research use)",
+        source_dataset="BrainMetShare",
+        source_url="https://stanfordaimi.azurewebsites.net/datasets/",
+    ),
+    "ct_org": Provenance(
+        license="CC-BY-3.0",
+        source_dataset="CT-ORG: CT volumes with multiple organ segmentations (TCIA)",
+        source_url="https://www.cancerimagingarchive.net/collection/ct-org/",
+        redistributable=True,
+    ),
+    "lidc_idri": Provenance(
+        license="CC-BY-3.0",
+        source_dataset="LIDC-IDRI (TCIA)",
+        source_url="https://www.cancerimagingarchive.net/collection/lidc-idri/",
+        redistributable=True,
+    ),
+    "cmmd": Provenance(
+        license="CC-BY-4.0",
+        source_dataset="CMMD - The Chinese Mammography Database (TCIA)",
+        source_url="https://www.cancerimagingarchive.net/collection/cmmd/",
+        redistributable=True,
+    ),
+}
+
+
+def get_provenance(dataset_name: str) -> Provenance:
+    """Return the provenance record for ``dataset_name``, or ``DEFAULT_PROVENANCE`` if unknown."""
+    return PROVENANCE.get(dataset_name, DEFAULT_PROVENANCE)

--- a/src/base/pipeline.py
+++ b/src/base/pipeline.py
@@ -10,7 +10,7 @@ The pipeline is used to process the dataset and save the processed dataset to th
 
 import warnings
 from abc import abstractmethod
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Callable, ClassVar, Optional
 
 from sklearn.pipeline import Pipeline
@@ -81,6 +81,114 @@ class OutputConfig:
 
 
 @dataclass
+class QualityConfig:
+    """Optional settings for the data-quality / validation steps (Theme D).
+
+    Every field has a safe default so the steps are opt-in and behave predictably when a
+    pipeline does not configure them. None of these steps alter UMIE ids or folder layout.
+    """
+
+    # Task 10 - duplicate / near-duplicate detection
+    duplicate_hash_size: int = 8  # side length of the perceptual-hash grid (hash is hash_size**2 bits)
+    duplicate_threshold: int = 5  # max Hamming distance between hashes to treat two images as near-duplicates
+    flag_duplicates_in_jsonl: bool = False  # additionally write a duplicate_group_id field into the JSONL
+    duplicate_reference_hashes: Optional[str] = None  # path to a JSON of {umie_path: hash} for cross-dataset overlap
+
+    # Task 11 - corrupt image detection
+    blank_std_threshold: float = 1.0  # pixel-std below which a frame is considered blank (all-black/all-white)
+    expected_min_size: Optional[tuple] = None  # (height, width) minimum; smaller images are reported as suspicious
+
+    # Task 13 - DICOM metadata validation
+    required_dicom_tags: Optional[dict] = None  # {tag_name: expected_value_or_None}; checked before conversion
+    exclude_invalid_dicom: bool = False  # drop files failing the DICOM-tag check from the returned file list
+
+
+@dataclass
+class PreprocessingConfig:
+    """Optional, opt-in image preprocessing settings (Theme E).
+
+    All transforms are off by default; they only touch pixel data, never naming/layout, and
+    never masks unless explicitly noted. Masks are always resampled/resized nearest-neighbour.
+    """
+
+    # Task 14 - intensity windowing / normalization
+    window_preset: Optional[str] = None  # named CT preset: lung | bone | soft_tissue | brain | abdomen | mediastinum
+
+    # Task 15 - CLAHE / histogram equalization
+    clahe_enabled: bool = False
+    clahe_clip_limit: float = 2.0
+    clahe_tile_grid_size: tuple = (8, 8)
+
+    # Task 16 - resolution / pixel-spacing normalization
+    target_spacing_mm: Optional[tuple] = None  # e.g. (1.0, 1.0, 1.0) for 1mm isotropic
+
+    # Task 17 - resize with aspect-ratio preservation
+    target_size: Optional[tuple] = None  # (height, width)
+    resize_strategy: str = "letterbox"  # pad | crop | letterbox | stretch
+
+    # Task 18 - bit-depth standardization
+    target_bit_depth: Optional[int] = None  # 8 or 16
+
+    # Task 19 - background / border auto-crop
+    autocrop_enabled: bool = False
+    autocrop_tolerance: int = 0  # pixels up to this value are treated as background when detecting borders
+
+
+@dataclass
+class MetadataConfig:
+    """Optional metadata-enrichment settings (Theme F). All JSONL additions are additive."""
+
+    # Task 20 - structured DICOM metadata extraction
+    dicom_tags: Optional[list] = None  # DICOM tag names to extract into the JSONL (PHI tags are skipped)
+    deidentify: bool = True  # never write known-PHI tags; shift dates by study_date_offset_days
+    metadata_sidecar: bool = False  # write a sidecar json instead of enriching the JSONL records
+
+    # Task 21 - patient-level reproducible splits
+    split_ratios: tuple = (0.7, 0.15, 0.15)  # train / val / test
+    split_seed: int = 42
+    split_manifest_only: bool = False  # write a split manifest only, do not add a `split` field to the JSONL
+    stratify_by_label: bool = True  # keep label distribution similar across splits where possible
+
+    # Task 23 - license / provenance tracking
+    add_provenance: bool = True  # populate license/source_dataset fields from config/provenance.py
+
+
+@dataclass
+class FormatConfig:
+    """Optional settings for the additional format / mask conversion steps (Theme G)."""
+
+    # Task 24 - DICOM-SEG / RTSTRUCT extraction
+    segmentation_structure_map: Optional[dict] = None  # {source_structure_name: target_mask_color}
+
+    # Task 25 - bbox (COCO / YOLO / VOC) -> mask conversion
+    bbox_format: Optional[str] = None  # coco | yolo | voc
+    bbox_class_map: Optional[dict] = None  # {source_class_id_or_name: target_mask_color}
+    bbox_as_filled: bool = True  # filled boxes (True) vs. outline only (False)
+
+    # Task 26 - multi-class mask merging
+    overlap_policy: str = "report"  # report | first | last | priority
+    merge_priority: Optional[list] = None  # mask colors in descending priority for overlap_policy="priority"
+
+
+@dataclass
+class ExportConfig:
+    """Optional reproducibility / export settings (Themes H & I)."""
+
+    # Task 27 - checksums + manifest
+    write_manifest: bool = True  # write a sha256 manifest of all outputs
+    verify_manifest: bool = False  # re-check outputs against an existing manifest instead of writing one
+
+    # Task 28 - incremental processing
+    force_reprocess: bool = False  # ignore existing outputs and reprocess everything
+
+    # Task 29 - parallel execution
+    num_workers: int = 1  # >1 enables multiprocessing in steps that support it (deterministic regardless of count)
+
+    # Task 30 - HuggingFace export
+    hf_export_path: Optional[str] = None  # local directory to write the Arrow dataset + card to
+
+
+@dataclass
 class PipelineArgs:
     """
     Arguments required by the processing pipeline of a given dataset.
@@ -116,6 +224,13 @@ class PipelineArgs:
     )
     xml_mask_creator: Optional[BaseXmlMaskCreator] = None  # function to create masks from xml files
     dicom_mapping_attribute: Optional[str] = None  # dicom attribute to map paths to
+    # Optional sub-configs for the additive, opt-in steps (Themes D-I). Passed as whole objects
+    # (rather than flat fields) to keep PipelineArgs from ballooning; default to None -> defaults.
+    quality: Optional[QualityConfig] = None
+    preprocessing: Optional[PreprocessingConfig] = None
+    metadata: Optional[MetadataConfig] = None
+    format_conversion: Optional[FormatConfig] = None
+    export: Optional[ExportConfig] = None
 
     def to_configs(self) -> tuple[IdentityConfig, DicomConfig, FileSelectionConfig, OutputConfig]:
         """Group the flat pipeline args into the four focused sub-configs (no value change).
@@ -169,6 +284,13 @@ class PipelineContext:
     dicom: DicomConfig
     file_selection: FileSelectionConfig
     output: OutputConfig
+    # Optional, opt-in sub-configs for Themes D-I. Defaulted so every existing direct
+    # construction of PipelineContext (e.g. in unit tests) keeps working unchanged.
+    quality: QualityConfig = field(default_factory=QualityConfig)
+    preprocessing: PreprocessingConfig = field(default_factory=PreprocessingConfig)
+    metadata: MetadataConfig = field(default_factory=MetadataConfig)
+    format_conversion: FormatConfig = field(default_factory=FormatConfig)
+    export: ExportConfig = field(default_factory=ExportConfig)
 
 
 @dataclass  # type: ignore[misc]
@@ -202,6 +324,12 @@ class BasePipeline:
             dicom=dicom,
             file_selection=file_selection,
             output=output,
+            # Opt-in Theme D-I sub-configs: use what the pipeline supplied, else safe defaults.
+            quality=self.pipeline_args.quality or QualityConfig(),
+            preprocessing=self.pipeline_args.preprocessing or PreprocessingConfig(),
+            metadata=self.pipeline_args.metadata or MetadataConfig(),
+            format_conversion=self.pipeline_args.format_conversion or FormatConfig(),
+            export=self.pipeline_args.export or ExportConfig(),
         )
 
         # Inherently-2D datasets (X-ray, pre-sliced) have no volumetric conversion step and

--- a/src/base/step.py
+++ b/src/base/step.py
@@ -12,10 +12,17 @@ from sklearn.base import TransformerMixin
 from base.creators.xml_mask import BaseXmlMaskCreator
 from base.selectors.img_selector import BaseImageSelector
 from base.selectors.mask_selector import BaseMaskSelector
-from constants import OutputMode
+from constants import REPORTS_FOLDER_NAME, OutputMode
 
 if TYPE_CHECKING:
-    from base.pipeline import PipelineContext
+    from base.pipeline import (
+        ExportConfig,
+        FormatConfig,
+        MetadataConfig,
+        PipelineContext,
+        PreprocessingConfig,
+        QualityConfig,
+    )
 
 
 class BaseStep(TransformerMixin):
@@ -184,6 +191,48 @@ class BaseStep(TransformerMixin):
     def xml_mask_creator(self) -> Optional[BaseXmlMaskCreator]:
         """Creator that builds masks from XML annotations."""
         return self.ctx.file_selection.xml_mask_creator
+
+    # --- Opt-in Theme D-I sub-configs (additive; every step inherits read-only views) ---
+    @property
+    def quality(self) -> "QualityConfig":
+        """Settings for the optional data-quality / validation steps (Theme D)."""
+        return self.ctx.quality
+
+    @property
+    def preprocessing(self) -> "PreprocessingConfig":
+        """Settings for the optional image-preprocessing steps (Theme E)."""
+        return self.ctx.preprocessing
+
+    @property
+    def metadata_config(self) -> "MetadataConfig":
+        """Settings for the optional metadata-enrichment steps (Theme F)."""
+        return self.ctx.metadata
+
+    @property
+    def format_config(self) -> "FormatConfig":
+        """Settings for the optional format / mask conversion steps (Theme G)."""
+        return self.ctx.format_conversion
+
+    @property
+    def export_config(self) -> "ExportConfig":
+        """Settings for the optional reproducibility / export steps (Themes H & I)."""
+        return self.ctx.export
+
+    @property
+    def dataset_root(self) -> str:
+        """Absolute path to this dataset's output root (``{target}/{uid}_{name}``)."""
+        return os.path.join(self.target_path, f"{self.dataset_uid}_{self.dataset_name}")
+
+    def reports_dir(self) -> str:
+        """Return (creating if needed) the per-dataset folder for optional analysis reports.
+
+        Used by the opt-in analysis steps (duplicate / corrupt-image / mask-quality / DICOM
+        validation / distribution). The folder lives outside ``Images``/``Masks`` so it never
+        affects the UMIE id, folder layout, or the golden file-tree of existing pipelines.
+        """
+        path = os.path.join(self.dataset_root, REPORTS_FOLDER_NAME)
+        os.makedirs(path, exist_ok=True)
+        return path
 
     def transform(
         self,

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 IMG_FOLDER_NAME = "Images"  # name of the folder with images in each target dataset
 MASK_FOLDER_NAME = "Masks"  # name of the folder with masks in each target dataset
+REPORTS_FOLDER_NAME = "reports"  # folder under each dataset's target dir for optional analysis reports
 
 TARGET_PATH = "./data/"  # name of the folder, where processed outputs will be placed
 

--- a/src/steps/__init__.py
+++ b/src/steps/__init__.py
@@ -3,13 +3,24 @@
 This module imports and makes available all the specific processing steps used in various data processing pipelines.
 Each step is a class that performs a specific operation, such as converting image formats, copying masks, or adding identifiers.
 These steps are used to construct the pipelines defined in the `pipelines` module.
+
+The optional, opt-in steps for Themes D-I (data quality, preprocessing, metadata enrichment, extra
+format support, reproducibility infrastructure, and HuggingFace export) are additive: they default to
+off / no-op and never change UMIE ids, the folder layout, or existing JSONL fields.
 """
 
 from .add_labels import AddLabels
+from .add_provenance import AddProvenance
 from .add_umie_ids import AddUmieIds
+from .apply_clahe import ApplyClahe
+from .apply_windowing import ApplyWindowing
+from .autocrop_borders import AutocropBorders
+from .check_mask_quality import CheckMaskQuality
 from .combine_multiple_masks import CombineMultipleMasks
+from .convert_bbox_to_mask import ConvertBboxToMask
 from .convert_dcm2nii import ConvertDcm2Nii
 from .convert_dcm2png import ConvertDcm2Png
+from .convert_dicom_seg import ConvertDicomSeg
 from .convert_jpg2png import ConvertJpg2Png
 from .convert_nii2nii import ConvertNii2Nii
 from .convert_nii2png import ConvertNii2Png
@@ -18,13 +29,25 @@ from .copy_masks import CopyMasks
 from .create_blank_masks import CreateBlankMasks
 from .create_file_to_dcm_attribute_mapping import CreateFileToDcmAttributeMapping
 from .create_file_tree import CreateFileTree
+from .create_manifest import CreateManifest
 from .create_masks_from_xml import CreateMasksFromXml
+from .create_splits import CreateSplits
 from .delete_imgs_with_no_annotations import DeleteImgsWithNoAnnotations
 from .delete_old_preprocessed_data import DeleteOldPreprocessedData
 from .delete_temp_files import DeleteTempFiles
 from .delete_temp_png import DeleteTempPng
+from .detect_corrupt_images import DetectCorruptImages
+from .detect_duplicates import DetectDuplicates
+from .export_huggingface import ExportHuggingFace
+from .extract_dicom_metadata import ExtractDicomMetadata
 from .get_file_paths import GetFilePaths
 from .masks_to_binary_colors import MasksToBinaryColors
+from .merge_masks import MergeMasks
+from .normalize_spacing import NormalizeSpacing
 from .recolor_masks import RecolorMasks
+from .resize_images import ResizeImages
+from .skip_processed import SkipProcessed
+from .standardize_bit_depth import StandardizeBitDepth
 from .store_source_paths import StoreSourcePaths
 from .validate_data import ValidateData
+from .validate_dicom_metadata import ValidateDicomMetadata

--- a/src/steps/add_provenance.py
+++ b/src/steps/add_provenance.py
@@ -1,0 +1,61 @@
+"""Add additive license / source-attribution fields to every JSONL record (Task 23).
+
+This optional, opt-in step stamps each dataset JSONL record with provenance metadata sourced
+from the single canonical table in ``config/provenance.py`` (``get_provenance``). It is purely
+additive: three new optional keys (``license``, ``source_dataset``, ``source_citation``) are
+added to each record and no existing field is changed. Unknown datasets fall back to
+``DEFAULT_PROVENANCE`` (``"unknown"``), so the fields are always populated.
+
+The step is a no-op when ``metadata_config.add_provenance`` is ``False``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import jsonlines
+
+from base.step import BaseStep
+from config.provenance import get_provenance
+
+
+class AddProvenance(BaseStep):
+    """Add additive ``license`` / ``source_dataset`` / ``source_citation`` JSONL fields (Task 23)."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Stamp every JSONL record with provenance from ``config/provenance.py``.
+
+        No-op when ``metadata_config.add_provenance`` is ``False`` or the JSONL is missing.
+        Existing fields and record order are preserved; only the additive provenance keys are
+        added. ``X`` is returned unchanged.
+
+        Args:
+            X (list): List of paths to the images (unchanged on return).
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        if not self.metadata_config.add_provenance:
+            return X
+        if not os.path.exists(self.json_path):
+            return X
+
+        print("Adding provenance (license / source attribution)...")
+        provenance = get_provenance(self.dataset_name)
+
+        records: list[dict] = []
+        with jsonlines.open(self.json_path, mode="r") as reader:
+            for obj in reader:
+                records.append(obj)
+
+        with jsonlines.open(self.json_path, mode="w") as writer:
+            for obj in records:
+                obj["license"] = provenance.license
+                obj["source_dataset"] = provenance.source_dataset
+                obj["source_citation"] = provenance.source_citation
+                writer.write(obj)
+
+        print(f"Provenance added to {len(records)} record(s): license={provenance.license!r}.")
+        return X

--- a/src/steps/apply_clahe.py
+++ b/src/steps/apply_clahe.py
@@ -1,0 +1,64 @@
+"""Optional, opt-in CLAHE contrast enhancement applied to image PNGs only (Theme E, Task 15)."""
+
+import glob
+import os
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class ApplyClahe(BaseStep):
+    """Apply Contrast Limited Adaptive Histogram Equalization to images (opt-in, images only)."""
+
+    def transform(self, X: list) -> list:
+        """Apply CLAHE to every image PNG when enabled; otherwise a no-op.
+
+        When ``self.preprocessing.clahe_enabled`` is False the step writes nothing and returns
+        ``X`` unchanged, so output files stay byte-identical. Masks are never touched. Only runs
+        in 2D (PNG) output mode.
+
+        Args:
+            X (list): List of paths to the images.
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        if not self.preprocessing.clahe_enabled or self.output_mode == OutputMode.VOLUMES_3D:
+            return X
+
+        clahe = cv2.createCLAHE(
+            clipLimit=self.preprocessing.clahe_clip_limit,
+            tileGridSize=tuple(self.preprocessing.clahe_tile_grid_size),
+        )
+        image_paths = glob.glob(os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.png"), recursive=True)
+        print("Applying CLAHE to images...")
+        for image_path in image_paths:
+            self._apply_clahe(image_path, clahe)
+        return X
+
+    def _apply_clahe(self, image_path: str, clahe: "cv2.CLAHE") -> None:
+        """Apply CLAHE to a single image, keeping the output a valid uint8 PNG.
+
+        Multi-channel images are equalized per channel so the result stays a readable PNG.
+
+        Args:
+            image_path (str): Path to the image PNG.
+            clahe (cv2.CLAHE): The configured CLAHE operator.
+        """
+        image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        if image is None:
+            return
+        # CLAHE operates on 8-bit (or 16-bit) single-channel data; downcast 16-bit to 8-bit so the
+        # output is a standard uint8 PNG, then equalize each channel independently.
+        if image.dtype != np.uint8:
+            normalized = np.empty_like(image, dtype=np.float64)
+            image = cv2.normalize(image, normalized, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+        if image.ndim == 2:
+            result = clahe.apply(image)
+        else:
+            channels = [clahe.apply(image[:, :, c]) for c in range(image.shape[2])]
+            result = cv2.merge(channels)
+        cv2.imwrite(image_path, result)

--- a/src/steps/apply_windowing.py
+++ b/src/steps/apply_windowing.py
@@ -1,0 +1,88 @@
+"""Optional, opt-in CT intensity windowing applied to image PNGs only (Theme E, Task 14)."""
+
+import glob
+import os
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+# Named CT windows as (center, width) in Hounsfield units. Reused by ApplyWindowing to resolve
+# self.preprocessing.window_preset; values are the conventional radiology presets.
+WINDOW_PRESETS: dict[str, tuple[int, int]] = {
+    "lung": (-600, 1500),
+    "mediastinum": (40, 400),
+    "abdomen": (50, 400),
+    "bone": (400, 1800),
+    "brain": (40, 80),
+    "soft_tissue": (50, 400),
+}
+
+
+class ApplyWindowing(BaseStep):
+    """Clip image intensities to a CT window and rescale to 0-255 uint8 (images only)."""
+
+    def transform(self, X: list) -> list:
+        """Apply the resolved CT window to every image PNG, leaving masks untouched.
+
+        The window is resolved from ``self.preprocessing.window_preset`` (a named preset), or
+        from ``self.window_center``/``self.window_width`` (DICOM config) as a fallback. When no
+        window can be resolved the step is a no-op and returns ``X`` unchanged. Only runs in 2D
+        (PNG) output mode; 3D volumes are windowed during conversion instead.
+
+        Args:
+            X (list): List of paths to the images.
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        window = self._resolve_window()
+        if window is None or self.output_mode == OutputMode.VOLUMES_3D:
+            return X
+
+        center, width = window
+        image_paths = glob.glob(os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.png"), recursive=True)
+        print("Applying CT windowing to images...")
+        for image_path in image_paths:
+            self._apply_windowing(image_path, center, width)
+        return X
+
+    def _resolve_window(self) -> Optional[tuple[float, float]]:
+        """Resolve the active (center, width); preset wins, then DICOM config, else None.
+
+        Returns:
+            Optional[tuple[float, float]]: The (center, width) to apply, or None for a no-op.
+        """
+        preset = self.preprocessing.window_preset
+        if preset is not None:
+            if preset not in WINDOW_PRESETS:
+                raise ValueError(f"Unknown window preset '{preset}'. Choose from {sorted(WINDOW_PRESETS)}.")
+            center, width = WINDOW_PRESETS[preset]
+            return float(center), float(width)
+        if self.window_center is not None and self.window_width is not None:
+            return float(self.window_center), float(self.window_width)
+        return None
+
+    def _apply_windowing(self, image_path: str, center: float, width: float) -> None:
+        """Clip a single image to the window and rescale linearly to 0-255 uint8.
+
+        Reads with ``cv2.IMREAD_UNCHANGED`` so the source bit depth is preserved before mapping.
+
+        Args:
+            image_path (str): Path to the image PNG.
+            center (float): Window center in source intensity units.
+            width (float): Window width in source intensity units.
+        """
+        image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        if image is None:
+            return
+        lower = center - width / 2
+        upper = center + width / 2
+        clipped = np.clip(image.astype(np.float64), lower, upper)
+        # Linear map [lower, upper] -> [0, 255]; width>0 by construction for the presets.
+        scale = 255.0 / width if width != 0 else 0.0
+        rescaled = ((clipped - lower) * scale).round().astype(np.uint8)
+        cv2.imwrite(image_path, rescaled)

--- a/src/steps/autocrop_borders.py
+++ b/src/steps/autocrop_borders.py
@@ -1,0 +1,77 @@
+"""Optional, opt-in auto-cropping of uniform black borders, keeping masks aligned (Theme E, Task 19)."""
+
+import glob
+import os
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class AutocropBorders(BaseStep):
+    """Crop uniform dark borders from images, applying the identical crop box to paired masks."""
+
+    def transform(self, X: list) -> list:
+        """Crop each image to its content bounding box and crop the paired mask identically.
+
+        Background is any pixel ``<= self.preprocessing.autocrop_tolerance``. The content bounding
+        box is computed from the image and the SAME box is applied to the paired mask so they stay
+        aligned. No-op when ``autocrop_enabled`` is False. Only runs in 2D (PNG) output mode.
+
+        Args:
+            X (list): List of paths to the images.
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        if not self.preprocessing.autocrop_enabled or self.output_mode == OutputMode.VOLUMES_3D:
+            return X
+
+        tolerance = self.preprocessing.autocrop_tolerance
+        image_paths = glob.glob(os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.png"), recursive=True)
+        print("Auto-cropping image borders...")
+        for image_path in image_paths:
+            image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+            if image is None:
+                continue
+            bbox = self._content_bbox(image, tolerance)
+            if bbox is None:
+                continue  # fully-background image: leave it untouched
+            top, bottom, left, right = bbox
+            cv2.imwrite(image_path, image[top:bottom, left:right])
+
+            mask_path = image_path.replace(
+                os.sep + self.image_folder_name + os.sep, os.sep + self.mask_folder_name + os.sep
+            )
+            if os.path.exists(mask_path):
+                mask = cv2.imread(mask_path, cv2.IMREAD_UNCHANGED)
+                if mask is not None:
+                    cv2.imwrite(mask_path, mask[top:bottom, left:right])
+        return X
+
+    @staticmethod
+    def _content_bbox(image: np.ndarray, tolerance: int) -> Optional[tuple[int, int, int, int]]:
+        """Compute the half-open (top, bottom, left, right) bounding box of non-background pixels.
+
+        Args:
+            image (np.ndarray): Image array (single- or multi-channel).
+            tolerance (int): Pixels with value <= this are treated as background.
+
+        Returns:
+            Optional[tuple[int, int, int, int]]: The bounding box, or None if all-background.
+        """
+        # Collapse channels so any channel above tolerance marks the pixel as content.
+        intensity = image if image.ndim == 2 else image.max(axis=2)
+        content = intensity > tolerance
+        rows = np.any(content, axis=1)
+        cols = np.any(content, axis=0)
+        if not rows.any() or not cols.any():
+            return None
+        row_idx = np.where(rows)[0]
+        col_idx = np.where(cols)[0]
+        top, bottom = int(row_idx[0]), int(row_idx[-1]) + 1
+        left, right = int(col_idx[0]), int(col_idx[-1]) + 1
+        return top, bottom, left, right

--- a/src/steps/check_mask_quality.py
+++ b/src/steps/check_mask_quality.py
@@ -1,0 +1,139 @@
+"""Check output mask quality: dimensions, colour vocabulary and emptiness."""
+
+import glob
+import json
+import os
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from config.masks import all_masks
+from constants import OutputMode
+
+
+class CheckMaskQuality(BaseStep):
+    """Check output mask quality: dimensions, colour vocabulary and emptiness."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Validate each output mask's dimensions, colours and emptiness; write a report.
+
+        For every output mask the step checks that its dimensions match the paired image, that
+        every unique pixel value is in the allowed vocabulary (``{0}`` plus the configured
+        ``target_color`` values, each of which must be a valid colour in ``config/masks.py``)
+        and flags all-zero (empty) masks. Failures are listed in a JSON report; nothing is
+        dropped. ``X`` is returned unchanged.
+
+        Args:
+            X (list): List of paths to the images.
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        print("Checking mask quality...")
+        allowed_colors = self._allowed_colors()
+        report: dict = {
+            "allowed_colors": sorted(allowed_colors),
+            "dim_mismatch": [],
+            "out_of_vocab_color": [],
+            "empty": [],
+        }
+        for mask_path in self._output_mask_paths():
+            self._inspect(mask_path, allowed_colors, report)
+        self._write_report(report)
+        failures = len(report["dim_mismatch"]) + len(report["out_of_vocab_color"]) + len(report["empty"])
+        print(f"Mask-quality check complete: {failures} issue(s) found.")
+        return X
+
+    def _output_mask_paths(self) -> list:
+        """Glob the dataset's output masks (PNG in 2D mode, ``.nii.gz`` in 3D mode)."""
+        extension = "nii.gz" if self.output_mode == OutputMode.VOLUMES_3D else "png"
+        pattern = os.path.join(self.dataset_root, f"**/{self.mask_folder_name}/*.{extension}")
+        return sorted(glob.glob(pattern, recursive=True))
+
+    def _allowed_colors(self) -> set:
+        """Build the allowed colour set: 0 plus configured target colours valid in config/masks.
+
+        Returns:
+            set: The allowed pixel values for any output mask.
+        """
+        valid_colors = {mask.color for mask in all_masks}
+        allowed = {0}
+        for mask_color in self.masks.values():
+            target = mask_color["target_color"]
+            if target in valid_colors:
+                allowed.add(target)
+        return allowed
+
+    def _read_array(self, path: str) -> Optional[np.ndarray]:
+        """Read a mask image or volume into a numpy array, or None if unreadable.
+
+        Args:
+            path (str): Path to the output mask.
+        Returns:
+            Optional[np.ndarray]: The pixel array, or None when it cannot be read.
+        """
+        if path.endswith(".nii.gz"):
+            try:
+                import nibabel as nib  # type: ignore[import-untyped]
+
+                return np.asarray(nib.load(path).get_fdata())  # type: ignore[attr-defined]
+            except Exception:
+                return None
+        return cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+
+    def _paired_image_array(self, mask_path: str) -> Optional[np.ndarray]:
+        """Read the image paired with a mask (same basename under the image folder).
+
+        Args:
+            mask_path (str): Path to the output mask.
+        Returns:
+            Optional[np.ndarray]: The paired image array, or None when missing/unreadable.
+        """
+        sep = os.sep + self.mask_folder_name + os.sep
+        replacement = os.sep + self.image_folder_name + os.sep
+        image_path = mask_path.replace(sep, replacement)
+        if not os.path.exists(image_path):
+            return None
+        return self._read_array(image_path)
+
+    def _inspect(self, mask_path: str, allowed_colors: set, report: dict) -> None:
+        """Classify a single output mask and record any failures in the report.
+
+        Args:
+            mask_path (str): Path to the output mask.
+            allowed_colors (set): The allowed pixel values.
+            report (dict): Mutable report accumulator.
+        """
+        umie_path = self.get_path_without_target_path(mask_path)
+        mask = self._read_array(mask_path)
+        if mask is None:
+            report["out_of_vocab_color"].append({"mask": umie_path, "reason": "unreadable"})
+            return
+
+        image = self._paired_image_array(mask_path)
+        if image is not None and image.shape[:2] != mask.shape[:2]:
+            report["dim_mismatch"].append(
+                {"mask": umie_path, "mask_shape": list(mask.shape[:2]), "image_shape": list(image.shape[:2])}
+            )
+
+        unique_values = {int(value) for value in np.unique(mask)}
+        invalid = sorted(unique_values - allowed_colors)
+        if invalid:
+            report["out_of_vocab_color"].append({"mask": umie_path, "invalid_colors": invalid})
+
+        if unique_values == {0}:
+            report["empty"].append(umie_path)
+
+    def _write_report(self, report: dict) -> None:
+        """Write the mask-quality report to JSON under the reports dir.
+
+        Args:
+            report (dict): The accumulated report.
+        """
+        report_path = os.path.join(self.reports_dir(), "mask_quality_report.json")
+        with open(report_path, "w") as handle:
+            json.dump(report, handle, indent=2)

--- a/src/steps/convert_bbox_to_mask.py
+++ b/src/steps/convert_bbox_to_mask.py
@@ -1,0 +1,281 @@
+"""Convert object-detection bbox annotations (COCO / YOLO / VOC) into UMIE mask PNGs."""
+
+import glob
+import json
+import os
+import xml.etree.ElementTree as ET
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+
+# A normalized box: (source class id/name, x1, y1, x2, y2) in absolute pixel coordinates.
+Box = tuple[object, int, int, int, int]
+
+
+class ConvertBboxToMask(BaseStep):
+    """Convert object-detection bbox annotations (COCO / YOLO / VOC) into UMIE mask PNGs.
+
+    Boxes are read from the source format named by ``self.format_config.bbox_format``
+    (``coco`` | ``yolo`` | ``voc``), mapped to a target colour via
+    ``self.format_config.bbox_class_map`` (``{source_class_id_or_name: target_mask_color}``)
+    and rasterized into a mask. Boxes are drawn filled when ``bbox_as_filled`` is set,
+    otherwise as a one-pixel outline. Multiple boxes for the same image accumulate into a
+    single mask. Output is an 8-bit single-channel PNG whose pixel value is the target colour.
+    """
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Convert bbox annotations found under the source path into UMIE mask PNGs.
+
+        Dispatches on ``self.format_config.bbox_format``. COCO reads a single JSON describing
+        many images; YOLO reads one ``.txt`` per image (sibling image gives its size); VOC
+        reads one XML per image (size taken from the XML). One accumulated mask is written per
+        image under the dataset's ``Masks`` folders. ``X`` is returned unchanged.
+
+        Args:
+            X (list): List of paths to the images.
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        bbox_format = self.format_config.bbox_format
+        if not bbox_format:
+            return X
+        print(f"Converting {bbox_format} bounding boxes to masks...")
+
+        if bbox_format == "coco":
+            written = self._convert_coco()
+        elif bbox_format == "yolo":
+            written = self._convert_yolo()
+        elif bbox_format == "voc":
+            written = self._convert_voc()
+        else:
+            raise ValueError(f"Unsupported bbox_format: {bbox_format!r}")
+
+        print(f"Bounding-box conversion complete: {written} mask(s) written.")
+        return X
+
+    # --- Source-format parsers (return absolute-pixel boxes) -------------------------------
+    @staticmethod
+    def _boxes_from_coco(coco: dict) -> dict[int, tuple[int, int, list[Box]]]:
+        """Parse a COCO annotation dict into per-image (height, width, boxes).
+
+        Args:
+            coco (dict): A parsed COCO JSON with ``images`` and ``annotations``.
+        Returns:
+            dict[int, tuple[int, int, list[Box]]]: image_id -> (height, width, boxes).
+        """
+        images: dict[int, tuple[int, int, list[Box]]] = {}
+        for image in coco.get("images", []):
+            images[int(image["id"])] = (int(image["height"]), int(image["width"]), [])
+        for annotation in coco.get("annotations", []):
+            image_id = int(annotation["image_id"])
+            if image_id not in images:
+                continue
+            x, y, w, h = annotation["bbox"]
+            box: Box = (annotation["category_id"], int(x), int(y), int(x + w), int(y + h))
+            images[image_id][2].append(box)
+        return images
+
+    @staticmethod
+    def _boxes_from_yolo(lines: list[str], height: int, width: int) -> list[Box]:
+        """Parse YOLO label lines (``class cx cy w h``, normalized) into absolute boxes.
+
+        Args:
+            lines (list[str]): Lines of a YOLO ``.txt`` label file.
+            height (int): Pixel height of the referenced image.
+            width (int): Pixel width of the referenced image.
+        Returns:
+            list[Box]: Boxes in absolute pixel coordinates.
+        """
+        boxes: list[Box] = []
+        for line in lines:
+            parts = line.split()
+            if len(parts) < 5:
+                continue
+            class_id = int(float(parts[0]))
+            cx, cy, w, h = (float(value) for value in parts[1:5])
+            x1 = int(round((cx - w / 2) * width))
+            y1 = int(round((cy - h / 2) * height))
+            x2 = int(round((cx + w / 2) * width))
+            y2 = int(round((cy + h / 2) * height))
+            boxes.append((class_id, x1, y1, x2, y2))
+        return boxes
+
+    @staticmethod
+    def _boxes_from_voc(xml_text: str) -> tuple[int, int, list[Box]]:
+        """Parse a Pascal VOC XML string into (height, width, boxes).
+
+        Args:
+            xml_text (str): The VOC annotation XML.
+        Returns:
+            tuple[int, int, list[Box]]: image height, width and the boxes it contains.
+        """
+        root = ET.fromstring(xml_text)
+        size = root.find("size")
+        height = int(size.findtext("height", "0")) if size is not None else 0
+        width = int(size.findtext("width", "0")) if size is not None else 0
+        boxes: list[Box] = []
+        for obj in root.findall("object"):
+            name = obj.findtext("name", "")
+            bndbox = obj.find("bndbox")
+            if bndbox is None:
+                continue
+            x1 = int(round(float(bndbox.findtext("xmin", "0"))))
+            y1 = int(round(float(bndbox.findtext("ymin", "0"))))
+            x2 = int(round(float(bndbox.findtext("xmax", "0"))))
+            y2 = int(round(float(bndbox.findtext("ymax", "0"))))
+            boxes.append((name, x1, y1, x2, y2))
+        return height, width, boxes
+
+    # --- Rendering -------------------------------------------------------------------------
+    def _render_mask(self, boxes: list[Box], height: int, width: int) -> np.ndarray:
+        """Rasterize boxes into one accumulated 8-bit single-channel mask.
+
+        Each box's source class is mapped to a target colour through
+        ``self.format_config.bbox_class_map`` (boxes with an unmapped class are skipped).
+        Boxes are drawn filled when ``bbox_as_filled`` is set, otherwise as a 1px outline.
+
+        Args:
+            boxes (list[Box]): Boxes in absolute pixel coordinates.
+            height (int): Output mask height.
+            width (int): Output mask width.
+        Returns:
+            np.ndarray: The accumulated mask.
+        """
+        class_map = self.format_config.bbox_class_map or {}
+        as_filled = self.format_config.bbox_as_filled
+        mask = np.zeros((height, width), dtype=np.uint8)
+        for class_key, x1, y1, x2, y2 in boxes:
+            color = self._lookup_color(class_map, class_key)
+            if color is None:
+                continue
+            point1 = (int(x1), int(y1))
+            point2 = (int(x2), int(y2))
+            thickness = -1 if as_filled else 1
+            cv2.rectangle(mask, point1, point2, int(color), thickness)
+        return mask
+
+    @staticmethod
+    def _lookup_color(class_map: dict, class_key: object) -> Optional[int]:
+        """Resolve a source class to its target colour, tolerating int/str key forms.
+
+        Args:
+            class_map (dict): ``{source_class_id_or_name: target_mask_color}``.
+            class_key (object): The box's source class id or name.
+        Returns:
+            Optional[int]: The target colour, or None when the class is unmapped.
+        """
+        if class_key in class_map:
+            return int(class_map[class_key])
+        # COCO category ids may be configured as strings (or vice versa); try both forms.
+        if str(class_key) in class_map:
+            return int(class_map[str(class_key)])
+        try:
+            numeric = int(class_key)  # type: ignore[call-overload]
+        except (TypeError, ValueError):
+            return None
+        if numeric in class_map:
+            return int(class_map[numeric])
+        return None
+
+    # --- Per-format drivers ----------------------------------------------------------------
+    def _convert_coco(self) -> int:
+        """Convert every COCO JSON under the source path into per-image masks.
+
+        Returns:
+            int: The number of masks written.
+        """
+        written = 0
+        for json_path in glob.glob(os.path.join(self.source_path, "**/*.json"), recursive=True):
+            with open(json_path) as handle:
+                coco = json.load(handle)
+            if "images" not in coco or "annotations" not in coco:
+                continue
+            id_to_name = {int(image["id"]): image["file_name"] for image in coco["images"]}
+            for image_id, (height, width, boxes) in self._boxes_from_coco(coco).items():
+                mask = self._render_mask(boxes, height, width)
+                written += self._write_mask(id_to_name[image_id], mask)
+        return written
+
+    def _convert_yolo(self) -> int:
+        """Convert every YOLO ``.txt`` (with a sibling image) under the source path.
+
+        Returns:
+            int: The number of masks written.
+        """
+        written = 0
+        for txt_path in glob.glob(os.path.join(self.source_path, "**/*.txt"), recursive=True):
+            image_path = self._sibling_image(txt_path)
+            if image_path is None:
+                continue
+            image = cv2.imread(image_path)
+            if image is None:
+                continue
+            height, width = image.shape[:2]
+            with open(txt_path) as handle:
+                lines = handle.read().splitlines()
+            boxes = self._boxes_from_yolo(lines, height, width)
+            mask = self._render_mask(boxes, height, width)
+            written += self._write_mask(os.path.basename(image_path), mask)
+        return written
+
+    def _convert_voc(self) -> int:
+        """Convert every Pascal VOC XML under the source path into per-image masks.
+
+        Returns:
+            int: The number of masks written.
+        """
+        written = 0
+        for xml_path in glob.glob(os.path.join(self.source_path, "**/*.xml"), recursive=True):
+            with open(xml_path) as handle:
+                xml_text = handle.read()
+            height, width, boxes = self._boxes_from_voc(xml_text)
+            if height == 0 or width == 0:
+                continue
+            mask = self._render_mask(boxes, height, width)
+            root = ET.fromstring(xml_text)
+            filename = root.findtext("filename") or os.path.splitext(os.path.basename(xml_path))[0]
+            written += self._write_mask(filename, mask)
+        return written
+
+    @staticmethod
+    def _sibling_image(label_path: str) -> Optional[str]:
+        """Find an image file sharing the label file's stem (YOLO convention).
+
+        Args:
+            label_path (str): Path to a YOLO ``.txt`` label file.
+        Returns:
+            Optional[str]: The sibling image path, or None when none exists.
+        """
+        stem = os.path.splitext(label_path)[0]
+        for extension in (".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff"):
+            candidate = stem + extension
+            if os.path.exists(candidate):
+                return candidate
+        return None
+
+    def _write_mask(self, image_file_name: str, mask: np.ndarray) -> int:
+        """Write a rendered mask under the dataset's Masks folder, returning 1 on success.
+
+        The output basename mirrors the source image file name with a ``.png`` extension so it
+        pairs with the converted image. Empty masks are still written so each annotated image
+        has a paired mask.
+
+        Args:
+            image_file_name (str): Source image file name the boxes belong to.
+            mask (np.ndarray): The rendered mask.
+        Returns:
+            int: 1 when a mask was written, 0 otherwise.
+        """
+        phase_id = next(iter(self.phases))
+        phase_name = self.phases[phase_id]
+        base = os.path.splitext(os.path.basename(image_file_name))[0] + ".png"
+        masks_dir = os.path.join(self.dataset_root, phase_name, self.mask_folder_name)
+        os.makedirs(masks_dir, exist_ok=True)
+        cv2.imwrite(os.path.join(masks_dir, base), mask)
+        return 1

--- a/src/steps/convert_dicom_seg.py
+++ b/src/steps/convert_dicom_seg.py
@@ -1,0 +1,422 @@
+"""Extract DICOM-SEG / RTSTRUCT segmentations into UMIE mask PNGs aligned to their images."""
+
+import glob
+import os
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+import pydicom
+
+from base.step import BaseStep
+from config.masks import all_masks
+
+
+class ConvertDicomSeg(BaseStep):
+    """Extract DICOM-SEG / RTSTRUCT segmentations into UMIE mask PNGs aligned to their images.
+
+    A DICOM-SEG object stores one binary plane per (segment, slice) in a multi-frame pixel
+    array; an RTSTRUCT stores polygon contours in patient coordinates. Both are decoded into
+    one single-channel mask per referenced image, with each structure painted in the target
+    colour from ``self.format_config.segmentation_structure_map``
+    (``{source_structure_name: target_mask_color}``), falling back to a matching colour in
+    ``config/masks.py`` by RadLex name. ``transform`` dispatches on the file ``Modality``
+    (``SEG`` vs ``RTSTRUCT``) over the ``.dcm`` files in ``X`` and writes the masks under the
+    dataset's ``Masks`` folders. Output pixel values follow ``config/masks.py`` conventions.
+    """
+
+    def transform(
+        self,
+        X: list,  # source file paths
+    ) -> list:
+        """Decode DICOM-SEG / RTSTRUCT files in ``X`` into per-slice UMIE mask PNGs.
+
+        Each ``.dcm`` whose ``Modality`` is ``SEG`` or ``RTSTRUCT`` is decoded; the resulting
+        per-reference masks are written under the dataset's ``Masks`` folder. ``X`` is
+        returned unchanged.
+
+        Args:
+            X (list): List of source file paths.
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        print("Converting DICOM-SEG / RTSTRUCT to masks...")
+        written = 0
+        for path in X:
+            if not str(path).endswith(".dcm"):
+                continue
+            try:
+                dataset = pydicom.dcmread(path)
+            except Exception:
+                continue
+            modality = getattr(dataset, "Modality", None)
+            if modality == "SEG":
+                written += self._handle_seg(dataset)
+            elif modality == "RTSTRUCT":
+                written += self._handle_rtstruct(dataset)
+        print(f"Segmentation conversion complete: {written} mask(s) written.")
+        return X
+
+    # --- Colour resolution -----------------------------------------------------------------
+    def _resolve_color(self, structure_name: Optional[str]) -> Optional[int]:
+        """Resolve a source structure name to a target mask colour.
+
+        Looks up ``self.format_config.segmentation_structure_map`` first, then falls back to a
+        ``config/masks.py`` mask whose ``radlex_name`` matches the structure name.
+
+        Args:
+            structure_name (Optional[str]): The SEG segment / RTSTRUCT ROI structure name.
+        Returns:
+            Optional[int]: The target colour, or None when the structure cannot be mapped.
+        """
+        if structure_name is None:
+            return None
+        mapping = self.format_config.segmentation_structure_map or {}
+        if structure_name in mapping:
+            return int(mapping[structure_name])
+        for mask in all_masks:
+            if mask.radlex_name == structure_name:
+                return int(mask.color)
+        return None
+
+    # --- DICOM-SEG path --------------------------------------------------------------------
+    def _handle_seg(self, dataset: pydicom.dataset.Dataset) -> int:
+        """Decode a SEG dataset to masks and write one PNG per referenced slice.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The SEG dataset.
+        Returns:
+            int: The number of masks written.
+        """
+        masks = self._seg_to_masks(dataset)
+        written = 0
+        for reference, mask in masks.items():
+            written += self._write_mask(str(reference), mask)
+        return written
+
+    def _segment_colors(self, dataset: pydicom.dataset.Dataset) -> dict[int, int]:
+        """Map each SEG segment number to its target colour via SegmentSequence labels.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The SEG dataset.
+        Returns:
+            dict[int, int]: ``{segment_number: target_color}`` for resolvable segments.
+        """
+        colors: dict[int, int] = {}
+        for segment in getattr(dataset, "SegmentSequence", []) or []:
+            number = int(getattr(segment, "SegmentNumber", 0))
+            name = getattr(segment, "SegmentLabel", None) or getattr(segment, "SegmentDescription", None)
+            color = self._resolve_color(name)
+            if color is not None:
+                colors[number] = color
+        return colors
+
+    def _seg_to_masks(self, dataset: pydicom.dataset.Dataset) -> dict[object, np.ndarray]:
+        """Build one mask per referenced slice from a multi-frame SEG dataset.
+
+        For each frame, the referenced segment number is read from
+        ``PerFrameFunctionalGroupsSequence -> SegmentIdentificationSequence`` and the
+        referenced image SOP UID from ``DerivationImageSequence``; frames are keyed by that
+        SOP UID when present, otherwise by frame index. The segment's target colour is written
+        wherever that frame's binary plane equals 1, accumulating across segments per slice.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The SEG dataset.
+        Returns:
+            dict[object, np.ndarray]: Mapping of referenced SOP UID (or frame index) to mask.
+        """
+        pixels = np.asarray(dataset.pixel_array)
+        if pixels.ndim == 2:  # a single-frame SEG
+            pixels = pixels[np.newaxis, ...]
+        rows, cols = pixels.shape[1], pixels.shape[2]
+        segment_colors = self._segment_colors(dataset)
+
+        per_frame = list(getattr(dataset, "PerFrameFunctionalGroupsSequence", []) or [])
+        masks: dict[object, np.ndarray] = {}
+        for index, frame_plane in enumerate(pixels):
+            frame_group = per_frame[index] if index < len(per_frame) else None
+            segment_number = self._frame_segment_number(frame_group)
+            color = segment_colors.get(segment_number)
+            if color is None:
+                continue
+            key = self._frame_reference(frame_group, index)
+            mask = masks.setdefault(key, np.zeros((rows, cols), dtype=np.uint8))
+            mask[frame_plane.astype(bool)] = color
+        return masks
+
+    @staticmethod
+    def _frame_segment_number(frame_group: Optional[pydicom.dataset.Dataset]) -> int:
+        """Read a frame's referenced segment number from its functional groups.
+
+        Args:
+            frame_group (Optional[pydicom.dataset.Dataset]): A PerFrameFunctionalGroups item.
+        Returns:
+            int: The referenced segment number, or 0 when unavailable.
+        """
+        if frame_group is None:
+            return 0
+        seg_id = getattr(frame_group, "SegmentIdentificationSequence", None)
+        if not seg_id:
+            return 0
+        return int(getattr(seg_id[0], "ReferencedSegmentNumber", 0))
+
+    @staticmethod
+    def _frame_reference(frame_group: Optional[pydicom.dataset.Dataset], index: int) -> object:
+        """Resolve the key identifying the image a SEG frame is aligned to.
+
+        Prefers the referenced source-image SOP UID (from ``DerivationImageSequence ->
+        SourceImageSequence``); falls back to the frame index when no reference is present.
+
+        Args:
+            frame_group (Optional[pydicom.dataset.Dataset]): A PerFrameFunctionalGroups item.
+            index (int): The frame's index in the pixel array.
+        Returns:
+            object: The referenced SOP Instance UID, or the frame index.
+        """
+        if frame_group is not None:
+            derivation = getattr(frame_group, "DerivationImageSequence", None)
+            if derivation:
+                source = getattr(derivation[0], "SourceImageSequence", None)
+                if source:
+                    uid = getattr(source[0], "ReferencedSOPInstanceUID", None)
+                    if uid:
+                        return str(uid)
+        return index
+
+    # --- RTSTRUCT path ---------------------------------------------------------------------
+    def _handle_rtstruct(self, dataset: pydicom.dataset.Dataset) -> int:
+        """Decode an RTSTRUCT dataset into per-slice masks and write them.
+
+        Each ``ROIContourSequence`` item's contours are rasterized onto the masks of the
+        referenced images, looked up from the SOP UIDs stored in the RTSTRUCT's referenced
+        image datasets, which must be discoverable next to the RTSTRUCT file.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The RTSTRUCT dataset.
+        Returns:
+            int: The number of masks written.
+        """
+        roi_names = self._roi_names(dataset)
+        image_geometry = self._reference_image_geometry(dataset)
+        masks: dict[str, np.ndarray] = {}
+        for roi_contour in getattr(dataset, "ROIContourSequence", []) or []:
+            roi_number = int(getattr(roi_contour, "ReferencedROINumber", 0))
+            color = self._resolve_color(roi_names.get(roi_number))
+            if color is None:
+                continue
+            for contour in getattr(roi_contour, "ContourSequence", []) or []:
+                self._rasterize_into(contour, image_geometry, color, masks)
+        written = 0
+        for sop_uid, mask in masks.items():
+            written += self._write_mask(sop_uid, mask)
+        return written
+
+    @staticmethod
+    def _roi_names(dataset: pydicom.dataset.Dataset) -> dict[int, str]:
+        """Map ROI numbers to their structure names from StructureSetROISequence.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The RTSTRUCT dataset.
+        Returns:
+            dict[int, str]: ``{roi_number: roi_name}``.
+        """
+        names: dict[int, str] = {}
+        for roi in getattr(dataset, "StructureSetROISequence", []) or []:
+            number = int(getattr(roi, "ROINumber", 0))
+            names[number] = str(getattr(roi, "ROIName", ""))
+        return names
+
+    def _reference_image_geometry(self, dataset: pydicom.dataset.Dataset) -> dict[str, dict]:
+        """Collect per-referenced-image geometry needed to rasterize contours.
+
+        Reads the referenced image SOP UIDs from the RTSTRUCT and loads each referenced DICOM
+        from the same directory as the RTSTRUCT (matched by SOP Instance UID) to obtain
+        ``ImagePositionPatient`` / ``ImageOrientationPatient`` / ``PixelSpacing`` / size.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The RTSTRUCT dataset.
+        Returns:
+            dict[str, dict]: ``{sop_uid: geometry}`` keyed by referenced image SOP UID.
+        """
+        wanted = self._referenced_sop_uids(dataset)
+        geometry: dict[str, dict] = {}
+        directory = os.path.dirname(str(getattr(dataset, "filename", "")) or ".")
+        for path in glob.glob(os.path.join(directory, "*.dcm")):
+            try:
+                image = pydicom.dcmread(path, stop_before_pixels=True)
+            except Exception:
+                continue
+            sop_uid = str(getattr(image, "SOPInstanceUID", ""))
+            if sop_uid and (not wanted or sop_uid in wanted) and hasattr(image, "ImagePositionPatient"):
+                geometry[sop_uid] = self._geometry_from_image(image)
+        return geometry
+
+    @staticmethod
+    def _geometry_from_image(image: pydicom.dataset.Dataset) -> dict:
+        """Extract the geometry fields used by the patient->pixel mapping from an image.
+
+        Args:
+            image (pydicom.dataset.Dataset): A referenced image dataset.
+        Returns:
+            dict: ``image_position`` / ``image_orientation`` / ``pixel_spacing`` / rows / cols.
+        """
+        return {
+            "image_position": [float(value) for value in image.ImagePositionPatient],
+            "image_orientation": [float(value) for value in image.ImageOrientationPatient],
+            "pixel_spacing": [float(value) for value in image.PixelSpacing],
+            "rows": int(image.Rows),
+            "cols": int(image.Columns),
+        }
+
+    @staticmethod
+    def _referenced_sop_uids(dataset: pydicom.dataset.Dataset) -> set[str]:
+        """Gather every referenced image SOP Instance UID from an RTSTRUCT.
+
+        Args:
+            dataset (pydicom.dataset.Dataset): The RTSTRUCT dataset.
+        Returns:
+            set[str]: The referenced SOP Instance UIDs (possibly empty).
+        """
+        uids: set[str] = set()
+        for ref_frame in getattr(dataset, "ReferencedFrameOfReferenceSequence", []) or []:
+            for study in getattr(ref_frame, "RTReferencedStudySequence", []) or []:
+                for series in getattr(study, "RTReferencedSeriesSequence", []) or []:
+                    for contour_image in getattr(series, "ContourImageSequence", []) or []:
+                        uid = getattr(contour_image, "ReferencedSOPInstanceUID", None)
+                        if uid:
+                            uids.add(str(uid))
+        return uids
+
+    def _rasterize_into(
+        self,
+        contour: pydicom.dataset.Dataset,
+        image_geometry: dict[str, dict],
+        color: int,
+        masks: dict[str, np.ndarray],
+    ) -> None:
+        """Rasterize one contour onto the mask of its referenced image.
+
+        Args:
+            contour (pydicom.dataset.Dataset): A ContourSequence item.
+            image_geometry (dict[str, dict]): ``{sop_uid: geometry}`` for referenced images.
+            color (int): The ROI's target colour.
+            masks (dict[str, np.ndarray]): Mutable per-SOP-UID mask accumulator.
+        """
+        sop_uid = self._contour_sop_uid(contour)
+        if sop_uid is None or sop_uid not in image_geometry:
+            return
+        geometry = image_geometry[sop_uid]
+        points = [float(value) for value in getattr(contour, "ContourData", [])]
+        points_xyz: list[tuple[float, float, float]] = [
+            (points[i], points[i + 1], points[i + 2]) for i in range(0, len(points) - 2, 3)
+        ]
+        polygon = self._rasterize_contour(
+            points_xyz,
+            geometry["image_position"],
+            geometry["image_orientation"],
+            geometry["pixel_spacing"],
+            geometry["rows"],
+            geometry["cols"],
+            color,
+        )
+        mask = masks.setdefault(sop_uid, np.zeros((geometry["rows"], geometry["cols"]), dtype=np.uint8))
+        mask[polygon > 0] = color
+
+    @staticmethod
+    def _contour_sop_uid(contour: pydicom.dataset.Dataset) -> Optional[str]:
+        """Read the referenced image SOP UID a contour lies on.
+
+        Args:
+            contour (pydicom.dataset.Dataset): A ContourSequence item.
+        Returns:
+            Optional[str]: The referenced SOP Instance UID, or None.
+        """
+        contour_images = getattr(contour, "ContourImageSequence", None)
+        if not contour_images:
+            return None
+        uid = getattr(contour_images[0], "ReferencedSOPInstanceUID", None)
+        return str(uid) if uid else None
+
+    @staticmethod
+    def _patient_to_pixel(
+        point_xyz: tuple[float, float, float],
+        image_position: list[float],
+        image_orientation: list[float],
+        pixel_spacing: list[float],
+    ) -> tuple[int, int]:
+        """Map a patient-coordinate point to (row, col) pixel indices.
+
+        Uses the standard DICOM image-plane model: the in-plane row/column direction cosines
+        from ``ImageOrientationPatient`` project the offset of the point from
+        ``ImagePositionPatient`` onto the image grid, scaled by ``PixelSpacing`` (rows, cols).
+
+        Args:
+            point_xyz (tuple[float, float, float]): Point in patient coordinates.
+            image_position (list[float]): The image's ImagePositionPatient.
+            image_orientation (list[float]): The image's ImageOrientationPatient (6 values).
+            pixel_spacing (list[float]): The image's PixelSpacing ``[row_spacing, col_spacing]``.
+        Returns:
+            tuple[int, int]: The (row, col) pixel indices.
+        """
+        row_cosine = np.array(image_orientation[0:3], dtype=float)
+        col_cosine = np.array(image_orientation[3:6], dtype=float)
+        origin = np.array(image_position, dtype=float)
+        offset = np.array(point_xyz, dtype=float) - origin
+        row_spacing, col_spacing = float(pixel_spacing[0]), float(pixel_spacing[1])
+        # DICOM: first ImageOrientationPatient triplet is the across-columns (x) direction,
+        # the second is the down-rows (y) direction.
+        col = float(np.dot(offset, row_cosine)) / col_spacing
+        row = float(np.dot(offset, col_cosine)) / row_spacing
+        return int(round(row)), int(round(col))
+
+    @classmethod
+    def _rasterize_contour(
+        cls,
+        points_xyz: list[tuple[float, float, float]],
+        image_position: list[float],
+        image_orientation: list[float],
+        pixel_spacing: list[float],
+        rows: int,
+        cols: int,
+        color: int,
+    ) -> np.ndarray:
+        """Rasterize a patient-coordinate polygon into a filled mask of the given colour.
+
+        Args:
+            points_xyz (list[tuple[float, float, float]]): Polygon vertices in patient coords.
+            image_position (list[float]): The image's ImagePositionPatient.
+            image_orientation (list[float]): The image's ImageOrientationPatient (6 values).
+            pixel_spacing (list[float]): The image's PixelSpacing ``[row_spacing, col_spacing]``.
+            rows (int): Output mask height.
+            cols (int): Output mask width.
+            color (int): The fill colour.
+        Returns:
+            np.ndarray: The rasterized mask.
+        """
+        mask = np.zeros((rows, cols), dtype=np.uint8)
+        if len(points_xyz) < 3:
+            return mask
+        pixel_points = [
+            cls._patient_to_pixel(point, image_position, image_orientation, pixel_spacing) for point in points_xyz
+        ]
+        # cv2.fillPoly expects (x, y) == (col, row) vertices.
+        polygon = np.array([[col, row] for row, col in pixel_points], dtype=np.int32)
+        cv2.fillPoly(mask, [polygon], (int(color),))
+        return mask
+
+    # --- Output ----------------------------------------------------------------------------
+    def _write_mask(self, reference: str, mask: np.ndarray) -> int:
+        """Write a decoded mask under the dataset's Masks folder, returning 1 on success.
+
+        Args:
+            reference (str): Referenced image identifier (SOP UID or frame index) used as stem.
+            mask (np.ndarray): The decoded mask.
+        Returns:
+            int: 1 when a mask was written, 0 otherwise.
+        """
+        phase_id = next(iter(self.phases))
+        phase_name = self.phases[phase_id]
+        masks_dir = os.path.join(self.dataset_root, phase_name, self.mask_folder_name)
+        os.makedirs(masks_dir, exist_ok=True)
+        cv2.imwrite(os.path.join(masks_dir, f"{reference}.png"), mask)
+        return 1

--- a/src/steps/create_manifest.py
+++ b/src/steps/create_manifest.py
@@ -1,0 +1,119 @@
+"""Compute SHA-256 checksums of dataset outputs and write (or verify) a manifest.
+
+This optional, opt-in reproducibility step (Theme H, Task 27) walks every output file
+under ``self.dataset_root`` and records its SHA-256 hash. The manifest is a JSON object
+mapping each file's posix path (relative to ``dataset_root``) to its hex digest.
+
+Two modes are controlled by :class:`~base.pipeline.ExportConfig`:
+
+* ``verify_manifest is False`` (default): build the manifest and write it to
+  ``reports_dir()/manifest.json``.
+* ``verify_manifest is True``: load the existing ``manifest.json`` and re-check the
+  current outputs against it, writing the differences to
+  ``reports_dir()/manifest_verification.json`` with three categories - ``missing``
+  (recorded in the manifest but absent on disk), ``changed`` (hash differs), and
+  ``extra`` (present on disk but not in the manifest). The manifest itself is left
+  untouched in verify mode.
+
+The ``reports/`` folder (where the manifest and verification report live) and the
+manifest file are always excluded from hashing, so the manifest never references itself
+and analysis reports never invalidate verification. The step reads files only; it never
+alters any image or JSONL output and returns ``X`` unchanged.
+"""
+
+import hashlib
+import json
+import os
+
+from base.step import BaseStep
+from constants import REPORTS_FOLDER_NAME
+
+
+class CreateManifest(BaseStep):
+    """Write or verify a SHA-256 manifest of every output file under ``dataset_root``."""
+
+    _MANIFEST_NAME = "manifest.json"
+    _VERIFICATION_NAME = "manifest_verification.json"
+    _CHUNK_SIZE = 1 << 20  # 1 MiB read buffer for streaming large files
+
+    def transform(self, X: list) -> list:
+        """Build or verify the output manifest, leaving the outputs and ``X`` unchanged.
+
+        Args:
+            X (list): List of paths passed through the pipeline.
+
+        Returns:
+            list: The same ``X``, unchanged.
+        """
+        if self.export_config.verify_manifest:
+            self._verify_manifest()
+        elif self.export_config.write_manifest:
+            self._write_manifest()
+        return X
+
+    def _sha256(self, path: str) -> str:
+        """Compute the SHA-256 hex digest of a file, streaming it in chunks.
+
+        Args:
+            path (str): Absolute path to the file to hash.
+
+        Returns:
+            str: The lowercase hex SHA-256 digest of the file's bytes.
+        """
+        digest = hashlib.sha256()
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(self._CHUNK_SIZE), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _build_manifest(self) -> dict[str, str]:
+        """Hash every output file under ``dataset_root`` (excluding the reports folder).
+
+        Returns:
+            dict[str, str]: Mapping of posix relative path (to ``dataset_root``) to digest.
+        """
+        manifest: dict[str, str] = {}
+        root = self.dataset_root
+        for current_dir, dirnames, filenames in os.walk(root):
+            # Never descend into the reports/ folder: it holds the manifest and analysis
+            # reports, neither of which is part of the reproducible image/JSONL output.
+            if os.path.relpath(current_dir, root) == os.curdir:
+                dirnames[:] = [d for d in dirnames if d != REPORTS_FOLDER_NAME]
+            for filename in filenames:
+                abs_path = os.path.join(current_dir, filename)
+                rel_path = os.path.relpath(abs_path, root).replace(os.sep, "/")
+                manifest[rel_path] = self._sha256(abs_path)
+        return dict(sorted(manifest.items()))
+
+    def _manifest_path(self) -> str:
+        """Return the absolute path to the manifest file under ``reports_dir()``."""
+        return os.path.join(self.reports_dir(), self._MANIFEST_NAME)
+
+    def _write_manifest(self) -> None:
+        """Build the manifest and write it as deterministic JSON to ``reports_dir()``."""
+        manifest = self._build_manifest()
+        with open(self._manifest_path(), "w", encoding="utf-8") as handle:
+            json.dump(manifest, handle, indent=2, sort_keys=True)
+
+    def _verify_manifest(self) -> None:
+        """Re-check current outputs against an existing manifest and write the report.
+
+        Compares the on-disk outputs to the recorded manifest and writes a
+        ``manifest_verification.json`` report with ``missing`` / ``changed`` / ``extra``
+        lists. The manifest is not rewritten in this mode.
+        """
+        manifest_path = self._manifest_path()
+        if not os.path.exists(manifest_path):
+            raise FileNotFoundError(f"No manifest to verify at {manifest_path}.")
+        with open(manifest_path, "r", encoding="utf-8") as handle:
+            recorded: dict[str, str] = json.load(handle)
+
+        current = self._build_manifest()
+
+        missing = sorted(rel for rel in recorded if rel not in current)
+        extra = sorted(rel for rel in current if rel not in recorded)
+        changed = sorted(rel for rel in recorded if rel in current and recorded[rel] != current[rel])
+
+        report = {"missing": missing, "changed": changed, "extra": extra}
+        with open(os.path.join(self.reports_dir(), self._VERIFICATION_NAME), "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)

--- a/src/steps/create_splits.py
+++ b/src/steps/create_splits.py
@@ -1,0 +1,205 @@
+"""Generate reproducible study-level stratified train/val/test splits (Task 21).
+
+This optional, opt-in step assigns every JSONL record to a ``train`` / ``val`` / ``test`` split.
+The split is keyed on ``study_id`` (NOT on the individual image), so every record sharing a
+study id always lands in the same split. This is critical for 3D volumes, where many slices
+share one study and an image-level split would leak slices of the same study across splits.
+
+Determinism
+-----------
+Assignment uses ``random.Random(metadata_config.split_seed)`` (a local, seeded RNG; the global
+``random`` state is never touched), so running twice with the same seed yields identical
+assignments. Ratios come from ``metadata_config.split_ratios`` (train, val, test).
+
+Stratification
+--------------
+When ``metadata_config.stratify_by_label`` is set, studies are grouped by their dominant label
+(the most frequent RadLex label across the study's records, or ``"__none__"`` when unlabelled)
+and the ratios are applied within each group, keeping the label distribution similar across
+splits.
+
+Output
+------
+Additive only: a ``split`` field is added to each JSONL record (existing keys and order are
+preserved). When ``metadata_config.split_manifest_only`` is set, the JSONL is left untouched and
+a ``reports_dir()/split_manifest.json`` mapping ``{study_id: split}`` is written instead.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from collections import Counter, defaultdict
+from typing import Any
+
+import jsonlines
+
+from base.step import BaseStep
+
+
+class CreateSplits(BaseStep):
+    """Assign reproducible study-level stratified train/val/test splits (Task 21)."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Compute study-level splits and write them to the JSONL (or a manifest).
+
+        Args:
+            X (list): List of paths to the images (unchanged on return).
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        if not os.path.exists(self.json_path):
+            return X
+
+        print("Creating reproducible study-level splits...")
+        records: list[dict] = []
+        with jsonlines.open(self.json_path, mode="r") as reader:
+            for obj in reader:
+                records.append(obj)
+
+        if not records:
+            return X
+
+        study_to_split = self._assign_splits(records)
+
+        if self.metadata_config.split_manifest_only:
+            self._write_manifest(study_to_split)
+        else:
+            self._enrich_jsonl(records, study_to_split)
+
+        counts = Counter(study_to_split.values())
+        print(f"Split assignment complete: {dict(counts)} across {len(study_to_split)} studies.")
+        return X
+
+    def _assign_splits(self, records: list[dict]) -> dict[str, str]:
+        """Assign each distinct ``study_id`` to a single split.
+
+        Args:
+            records (list[dict]): All JSONL records.
+        Returns:
+            dict[str, str]: Mapping of ``study_id`` to ``"train"`` / ``"val"`` / ``"test"``.
+        """
+        study_groups = self._group_studies(records)
+        rng = random.Random(self.metadata_config.split_seed)
+
+        study_to_split: dict[str, str] = {}
+        # Iterate strata in a deterministic order (sorted by group key) so seeding is stable.
+        for group_key in sorted(study_groups.keys()):
+            studies = sorted(study_groups[group_key])
+            for study_id, split in self._split_group(studies, rng).items():
+                study_to_split[study_id] = split
+        return study_to_split
+
+    def _group_studies(self, records: list[dict]) -> dict[str, list[str]]:
+        """Group distinct study ids by their stratification key (dominant label).
+
+        When ``stratify_by_label`` is off, every study lands in a single ``"__all__"`` group.
+
+        Args:
+            records (list[dict]): All JSONL records.
+        Returns:
+            dict[str, list[str]]: ``{group_key: [study_id, ...]}`` with distinct study ids.
+        """
+        if not self.metadata_config.stratify_by_label:
+            studies = sorted({str(obj.get("study_id", "")) for obj in records})
+            return {"__all__": studies}
+
+        # Accumulate label votes per study across all its records, then pick the dominant label.
+        votes: dict[str, Counter] = defaultdict(Counter)
+        for obj in records:
+            study_id = str(obj.get("study_id", ""))
+            for radlex_name in self._record_labels(obj):
+                votes[study_id][radlex_name] += 1
+            # Ensure unlabelled studies still appear (with no votes).
+            votes.setdefault(study_id, Counter())
+
+        groups: dict[str, list[str]] = defaultdict(list)
+        for study_id, counter in votes.items():
+            dominant = counter.most_common(1)[0][0] if counter else "__none__"
+            groups[dominant].append(study_id)
+        return groups
+
+    @staticmethod
+    def _record_labels(record: dict) -> list[str]:
+        """Extract the RadLex label names from a record's ``labels`` list.
+
+        ``labels`` is a list of ``{radlex_name: grade}`` dicts; this returns the radlex names.
+
+        Args:
+            record (dict): One JSONL record.
+        Returns:
+            list[str]: RadLex label names present on the record (possibly empty).
+        """
+        names: list[str] = []
+        for label in record.get("labels", []) or []:
+            if isinstance(label, dict):
+                names.extend(str(key) for key in label.keys())
+        return names
+
+    def _split_group(self, studies: list[str], rng: random.Random) -> dict[str, str]:
+        """Split one ordered group of study ids into train/val/test by the configured ratios.
+
+        Uses the shared seeded RNG to shuffle, so assignment is reproducible across runs and the
+        split sizes follow ``split_ratios``.
+
+        Args:
+            studies (list[str]): Distinct study ids in this stratum (pre-sorted).
+            rng (random.Random): The shared seeded RNG.
+        Returns:
+            dict[str, str]: ``{study_id: split}`` for this group.
+        """
+        shuffled = list(studies)
+        rng.shuffle(shuffled)
+
+        train_ratio, val_ratio, _test_ratio = self.metadata_config.split_ratios
+        total = len(shuffled)
+        n_train = int(round(total * train_ratio))
+        n_val = int(round(total * val_ratio))
+        # Guard against rounding overflow; test gets whatever remains.
+        n_train = min(n_train, total)
+        n_val = min(n_val, total - n_train)
+
+        assignment: dict[str, str] = {}
+        for index, study_id in enumerate(shuffled):
+            if index < n_train:
+                assignment[study_id] = "train"
+            elif index < n_train + n_val:
+                assignment[study_id] = "val"
+            else:
+                assignment[study_id] = "test"
+        return assignment
+
+    def _enrich_jsonl(self, records: list[dict], study_to_split: dict[str, str]) -> None:
+        """Rewrite the JSONL in place, adding an additive ``split`` field to each record.
+
+        Existing keys and record order are preserved.
+
+        Args:
+            records (list[dict]): All JSONL records, in original order.
+            study_to_split (dict[str, str]): ``{study_id: split}`` mapping.
+        """
+        with jsonlines.open(self.json_path, mode="w") as writer:
+            for obj in records:
+                study_id = str(obj.get("study_id", ""))
+                obj["split"] = study_to_split.get(study_id, "train")
+                writer.write(obj)
+
+    def _write_manifest(self, study_to_split: dict[str, str]) -> None:
+        """Write the ``{study_id: split}`` manifest to JSON under the reports dir.
+
+        Args:
+            study_to_split (dict[str, str]): ``{study_id: split}`` mapping.
+        """
+        manifest: dict[str, Any] = {
+            "split_seed": self.metadata_config.split_seed,
+            "split_ratios": list(self.metadata_config.split_ratios),
+            "stratify_by_label": self.metadata_config.stratify_by_label,
+            "study_to_split": study_to_split,
+        }
+        path = os.path.join(self.reports_dir(), "split_manifest.json")
+        with open(path, "w") as handle:
+            json.dump(manifest, handle, indent=2)

--- a/src/steps/detect_corrupt_images.py
+++ b/src/steps/detect_corrupt_images.py
@@ -1,0 +1,114 @@
+"""Detect corrupt, truncated, blank or undersized output images and write a report."""
+
+import glob
+import json
+import os
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class DetectCorruptImages(BaseStep):
+    """Detect corrupt, truncated, blank or undersized output images and write a report."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Verify each output image is readable, large enough and not blank; write a report.
+
+        Each output image (PNG, or ``.nii.gz`` in 3D mode) is categorised as ``unreadable``,
+        ``truncated``, ``blank`` (pixel std below ``quality.blank_std_threshold``) or
+        ``too_small`` (below ``quality.expected_min_size``). The categories and a flat
+        quarantine list are written to a JSON report. ``X`` is returned unchanged; nothing is
+        ever deleted.
+
+        Args:
+            X (list): List of paths to the images.
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        print("Detecting corrupt images...")
+        report: dict = {
+            "unreadable": [],
+            "truncated": [],
+            "blank": [],
+            "too_small": [],
+            "quarantine": [],
+        }
+        for path in self._output_image_paths():
+            self._inspect(path, report)
+        self._write_report(report)
+        print(f"Corrupt-image detection complete: {len(report['quarantine'])} image(s) quarantined.")
+        return X
+
+    def _output_image_paths(self) -> list:
+        """Glob the dataset's output images (PNG in 2D mode, ``.nii.gz`` in 3D mode)."""
+        extension = "nii.gz" if self.output_mode == OutputMode.VOLUMES_3D else "png"
+        pattern = os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.{extension}")
+        return sorted(glob.glob(pattern, recursive=True))
+
+    def _read_array(self, path: str) -> Optional[np.ndarray]:
+        """Read an output image or volume into a numpy array, or None if unreadable.
+
+        Args:
+            path (str): Path to the output image or volume.
+        Returns:
+            Optional[np.ndarray]: The pixel array, or None when it cannot be read.
+        """
+        if path.endswith(".nii.gz"):
+            try:
+                import nibabel as nib  # type: ignore[import-untyped]
+
+                return np.asarray(nib.load(path).get_fdata())  # type: ignore[attr-defined]
+            except Exception:
+                return None
+        try:
+            image = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+        except Exception:
+            return None
+        return image
+
+    def _inspect(self, path: str, report: dict) -> None:
+        """Classify a single output image and append it to the relevant report buckets.
+
+        Args:
+            path (str): Path to the output image.
+            report (dict): Mutable report accumulator.
+        """
+        umie_path = self.get_path_without_target_path(path)
+        array = self._read_array(path)
+
+        # An unreadable file is either genuinely corrupt or truncated; distinguish by whether
+        # the file has any bytes at all so empty/clipped outputs are reported as "truncated".
+        if array is None or getattr(array, "size", 0) == 0:
+            category = "truncated" if os.path.getsize(path) == 0 else "unreadable"
+            report[category].append(umie_path)
+            report["quarantine"].append(umie_path)
+            return
+
+        if array.ndim >= 2:
+            height, width = array.shape[0], array.shape[1]
+            min_size = self.quality.expected_min_size
+            if min_size is not None and (height < min_size[0] or width < min_size[1]):
+                report["too_small"].append(umie_path)
+                report["quarantine"].append(umie_path)
+
+        if float(np.std(array)) < self.quality.blank_std_threshold:
+            report["blank"].append(umie_path)
+            if umie_path not in report["quarantine"]:
+                report["quarantine"].append(umie_path)
+
+    def _write_report(self, report: dict) -> None:
+        """Write the corrupt-image report to JSON under the reports dir.
+
+        Args:
+            report (dict): The accumulated report.
+        """
+        report_path = os.path.join(self.reports_dir(), "corrupt_images_report.json")
+        with open(report_path, "w") as handle:
+            json.dump(report, handle, indent=2)

--- a/src/steps/detect_duplicates.py
+++ b/src/steps/detect_duplicates.py
@@ -1,0 +1,230 @@
+"""Detect duplicate and near-duplicate output images using a perceptual (dHash) hash."""
+
+import csv
+import glob
+import json
+import os
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import jsonlines
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class DetectDuplicates(BaseStep):
+    """Detect duplicate and near-duplicate output images using a perceptual (dHash) hash."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Detect duplicate / near-duplicate output images and write reports; never deletes.
+
+        Computes a dHash for every output image, clusters images whose pairwise Hamming
+        distance is within ``quality.duplicate_threshold`` (optionally comparing against an
+        external reference-hash JSON), writes a JSON and CSV report and, when
+        ``quality.flag_duplicates_in_jsonl`` is set, adds an additive ``duplicate_group_id``
+        field to clustered JSONL records. ``X`` is returned unchanged so the step chains.
+
+        Args:
+            X (list): List of paths to the images.
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        print("Detecting duplicate images...")
+        hashes = self._compute_hashes()
+        reference = self._load_reference_hashes()
+        clusters = self._cluster(hashes, reference)
+        self._write_reports(clusters)
+        if self.quality.flag_duplicates_in_jsonl:
+            self._flag_in_jsonl(clusters)
+        print(f"Duplicate detection complete: {len(clusters)} cluster(s) found.")
+        return X
+
+    def _output_image_paths(self) -> list:
+        """Glob the dataset's output images (PNG in 2D mode, ``.nii.gz`` in 3D mode)."""
+        extension = "nii.gz" if self.output_mode == OutputMode.VOLUMES_3D else "png"
+        pattern = os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.{extension}")
+        return sorted(glob.glob(pattern, recursive=True))
+
+    def _dhash(self, image: np.ndarray) -> int:
+        """Compute the difference hash of a grayscale image as a ``hash_size**2`` bit integer.
+
+        Args:
+            image (np.ndarray): Grayscale image array.
+        Returns:
+            int: The perceptual hash encoded as an integer.
+        """
+        hash_size = self.quality.duplicate_hash_size
+        resized = cv2.resize(image, (hash_size + 1, hash_size), interpolation=cv2.INTER_AREA)
+        diff = resized[:, 1:] > resized[:, :-1]
+        value = 0
+        for bit in diff.flatten():
+            value = (value << 1) | int(bool(bit))
+        return value
+
+    def _load_image_grayscale(self, path: str) -> Optional[np.ndarray]:
+        """Load an output image as a 2D grayscale array, or None if it cannot be read.
+
+        Args:
+            path (str): Path to the output image or volume.
+        Returns:
+            Optional[np.ndarray]: Grayscale array, or None when unreadable.
+        """
+        if path.endswith(".nii.gz"):
+            try:
+                import nibabel as nib  # type: ignore[import-untyped]
+
+                data = np.asarray(nib.load(path).get_fdata())  # type: ignore[attr-defined]
+                if data.ndim > 2:
+                    data = data.reshape(data.shape[0], -1)
+                return data.astype(np.float32)
+            except Exception:
+                return None
+        image = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+        return image
+
+    def _compute_hashes(self) -> dict:
+        """Compute the dHash of every readable output image keyed by its UMIE-relative path.
+
+        Returns:
+            dict: Mapping of ``umie_path`` to its integer perceptual hash.
+        """
+        hashes: dict = {}
+        for path in self._output_image_paths():
+            image = self._load_image_grayscale(path)
+            if image is None:
+                continue
+            umie_path = self.get_path_without_target_path(path)
+            hashes[umie_path] = self._dhash(image)
+        return hashes
+
+    def _load_reference_hashes(self) -> dict:
+        """Load the optional cross-dataset reference-hash JSON ``{umie_path: hash}``.
+
+        Returns:
+            dict: Reference hashes, or an empty dict when none are configured.
+        """
+        ref_path = self.quality.duplicate_reference_hashes
+        if not ref_path or not os.path.exists(ref_path):
+            return {}
+        with open(ref_path) as handle:
+            raw = json.load(handle)
+        return {key: int(value) for key, value in raw.items()}
+
+    @staticmethod
+    def _hamming(left: int, right: int) -> int:
+        """Return the Hamming distance between two integer hashes.
+
+        Args:
+            left (int): First hash.
+            right (int): Second hash.
+        Returns:
+            int: Number of differing bits.
+        """
+        return int(bin(left ^ right).count("1"))
+
+    def _cluster(self, hashes: dict, reference: dict) -> list:
+        """Cluster images whose pairwise Hamming distance is within the configured threshold.
+
+        Reference hashes participate in clustering so cross-dataset overlaps surface, but a
+        cluster is only reported when it contains at least one image from this dataset.
+
+        Args:
+            hashes (dict): This dataset's ``{umie_path: hash}`` mapping.
+            reference (dict): Optional external ``{umie_path: hash}`` mapping.
+        Returns:
+            list: Clusters as dicts with ``members``, ``representative`` and ``max_distance``.
+        """
+        threshold = self.quality.duplicate_threshold
+        own_keys = set(hashes.keys())
+        combined = {**reference, **hashes}  # this dataset's hashes win on key collisions
+        items = list(combined.items())
+
+        parent = {key: key for key, _ in items}
+
+        def find(node: str) -> str:
+            while parent[node] != node:
+                parent[node] = parent[parent[node]]
+                node = parent[node]
+            return node
+
+        def union(left: str, right: str) -> None:
+            parent[find(left)] = find(right)
+
+        for i in range(len(items)):
+            for j in range(i + 1, len(items)):
+                if self._hamming(items[i][1], items[j][1]) <= threshold:
+                    union(items[i][0], items[j][0])
+
+        groups: dict = {}
+        for key, _ in items:
+            groups.setdefault(find(key), []).append(key)
+
+        clusters = []
+        for members in groups.values():
+            if len(members) < 2:
+                continue
+            if not any(member in own_keys for member in members):
+                continue
+            ordered = sorted(members)
+            max_distance = 0
+            for i in range(len(ordered)):
+                for j in range(i + 1, len(ordered)):
+                    max_distance = max(max_distance, self._hamming(combined[ordered[i]], combined[ordered[j]]))
+            representative = next((member for member in ordered if member in own_keys), ordered[0])
+            clusters.append(
+                {
+                    "members": ordered,
+                    "representative": representative,
+                    "max_distance": max_distance,
+                }
+            )
+        return sorted(clusters, key=lambda cluster: cluster["representative"])
+
+    def _write_reports(self, clusters: list) -> None:
+        """Write the duplicate clusters to a JSON and a CSV report under the reports dir.
+
+        Args:
+            clusters (list): The detected duplicate clusters.
+        """
+        reports_dir = self.reports_dir()
+        json_path = os.path.join(reports_dir, "duplicates_report.json")
+        with open(json_path, "w") as handle:
+            json.dump({"threshold": self.quality.duplicate_threshold, "clusters": clusters}, handle, indent=2)
+
+        csv_path = os.path.join(reports_dir, "duplicates_report.csv")
+        with open(csv_path, "w", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["group_id", "member", "representative", "max_distance"])
+            for group_id, cluster in enumerate(clusters):
+                for member in cluster["members"]:
+                    writer.writerow([group_id, member, cluster["representative"], cluster["max_distance"]])
+
+    def _flag_in_jsonl(self, clusters: list) -> None:
+        """Add an additive ``duplicate_group_id`` to clustered records, preserving order.
+
+        Args:
+            clusters (list): The detected duplicate clusters.
+        """
+        if not os.path.exists(self.json_path):
+            return
+        member_to_group = {}
+        for group_id, cluster in enumerate(clusters):
+            for member in cluster["members"]:
+                member_to_group[member] = group_id
+
+        updated = []
+        with jsonlines.open(self.json_path, mode="r") as reader:
+            for obj in reader:
+                member_group = member_to_group.get(obj.get("umie_path"))
+                if member_group is not None:
+                    obj["duplicate_group_id"] = member_group
+                updated.append(obj)
+
+        with jsonlines.open(self.json_path, mode="w") as writer:
+            for obj in updated:
+                writer.write(obj)

--- a/src/steps/export_huggingface.py
+++ b/src/steps/export_huggingface.py
@@ -1,0 +1,291 @@
+"""Export the processed dataset to the HuggingFace ``datasets`` Arrow format on disk (Task 30).
+
+This optional, opt-in pipeline step reads the finished dataset JSONL produced by the rest of
+the pipeline and materializes it as a HuggingFace ``datasets`` dataset on local disk via
+``DatasetDict.save_to_disk`` -- there is no network push (publishing to the Hub stays in
+``utils/huggingface_cli.py``). The export is purely additive: it only *reads* the processed
+outputs (the JSONL and the referenced PNG images/masks) and *writes* a self-contained
+HuggingFace dataset directory plus a dataset card, never touching the UMIE ids, folder layout,
+or the existing image / JSONL outputs.
+
+The on-disk schema mirrors the push-based logic in ``utils/huggingface_cli.py``: the image
+(and mask, when present) columns are cast with ``datasets.Image()``, ``labels`` is flattened to
+a ``{name: grade}`` dict and stored as a JSON string, and ``dataset_uid`` / ``study_id`` are
+kept as strings. When a ``split`` field is present the records are grouped into a
+``DatasetDict`` with ``train`` / ``val`` / ``test`` splits; otherwise everything is placed in a
+single ``train`` split so the output is always a ``DatasetDict`` and therefore consistently
+round-trip-able with ``datasets.load_from_disk``.
+
+Future work: additional first-class exporters for medical / training-oriented formats are
+planned but intentionally out of scope here -- MONAI / nnU-Net dataset layouts for segmentation
+training, and sharded ``WebDataset`` / ``TFRecord`` exports for large-scale streaming.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pandas as pd
+
+from base.step import BaseStep
+from config.provenance import get_provenance
+from datasets import (  # type: ignore[attr-defined]
+    Dataset,
+    DatasetDict,
+    Features,
+    Image,
+    Value,
+)
+
+# Canonical ordering of splits when a "split" field is present in the JSONL (Task 21).
+SPLIT_ORDER = ("train", "val", "test")
+# Fallback single-split name used when the records carry no "split" field.
+DEFAULT_SPLIT = "train"
+
+
+class ExportHuggingFace(BaseStep):
+    """Write the processed dataset to a local HuggingFace Arrow dataset + card (Task 30)."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Materialize the dataset JSONL as a HuggingFace ``datasets`` dataset on disk.
+
+        Reads ``self.json_path``, builds absolute image (and mask) paths from
+        ``self.target_path``, casts the schema to mirror ``utils/huggingface_cli`` and writes a
+        ``DatasetDict`` (split-aware when a ``split`` field is present) to the configured export
+        directory together with an auto-generated ``README.md`` dataset card. ``X`` is returned
+        unchanged; the step is a no-op when the source JSONL does not exist.
+
+        Args:
+            X (list): List of paths to the images (unchanged on return).
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        if not os.path.exists(self.json_path):
+            print(f"HuggingFace export skipped: dataset JSONL not found at {self.json_path}.")
+            return X
+
+        export_dir = self.export_config.hf_export_path or os.path.join(self.dataset_root, "huggingface")
+
+        records = self._read_records()
+        if not records:
+            print("HuggingFace export skipped: dataset JSONL is empty.")
+            return X
+
+        has_masks = any(bool(record.get("mask_path")) for record in records)
+        features = self._build_features(records[0], has_masks)
+
+        print(f"Exporting {len(records)} record(s) to HuggingFace dataset at {export_dir} ...")
+        dataset_dict = self._build_dataset_dict(records, features, has_masks)
+
+        os.makedirs(export_dir, exist_ok=True)
+        dataset_dict.save_to_disk(export_dir)
+        self._write_card(export_dir, records, dataset_dict)
+
+        print(f"HuggingFace export complete: {sum(d.num_rows for d in dataset_dict.values())} record(s) written.")
+        return X
+
+    def _read_records(self) -> list[dict[str, Any]]:
+        """Read the dataset JSONL into a list of plain dict records via pandas.
+
+        Returns:
+            list[dict[str, Any]]: One dict per JSONL line, in file order.
+        """
+        df = pd.read_json(self.json_path, lines=True)
+        return df.to_dict(orient="records")
+
+    @staticmethod
+    def _flatten_labels(labels: Any) -> str:
+        """Flatten a list of ``{name: grade}`` dicts into one ``{name: grade}`` JSON string.
+
+        Mirrors ``utils/huggingface_cli.transform_labels`` so the on-disk schema matches the
+        push-based export. Accepts either an already-decoded list or a JSON string.
+
+        Args:
+            labels (Any): The raw ``labels`` value from a record (list of dicts or JSON string).
+
+        Returns:
+            str: A JSON string of the merged ``{name: grade}`` mapping.
+        """
+        if isinstance(labels, str):
+            try:
+                labels = json.loads(labels)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON format: {labels}") from exc
+
+        merged: dict[str, Any] = {}
+        for label in labels or []:
+            if isinstance(label, dict):
+                for key, value in label.items():
+                    if value is not None:
+                        merged[key] = value
+            else:
+                raise ValueError(f"Invalid label type: {type(label)}")
+        return json.dumps(merged)
+
+    def _build_features(self, sample_record: dict[str, Any], has_masks: bool) -> Features:
+        """Build the HuggingFace ``Features`` schema for the export.
+
+        The ``image`` (and ``mask`` when masks exist) columns are cast with ``Image()``;
+        ``labels`` is a JSON string; ``dataset_uid`` / ``study_id`` are strings; every other
+        scalar field present in the sample record is kept as a string ``Value``.
+
+        Args:
+            sample_record (dict[str, Any]): A representative record used to discover columns.
+            has_masks (bool): Whether the dataset has masks (adds a ``mask`` Image column).
+
+        Returns:
+            Features: The HuggingFace feature schema for the exported dataset.
+        """
+        feature_map: dict[str, Any] = {"image": Image(), "labels": Value("string")}
+        if has_masks:
+            feature_map["mask"] = Image()
+
+        # Keep every remaining scalar field (e.g. dataset_name, phase_name, comparative,
+        # umie_id, split, license, source_dataset, source_labels) as a string Value. Keys that
+        # become the image/mask columns are remapped from umie_path / mask_path below.
+        skip = {"umie_path", "mask_path", "labels"}
+        for key in sample_record:
+            if key in skip:
+                continue
+            feature_map[key] = Value("string")
+        return Features(feature_map)
+
+    def _record_to_row(self, record: dict[str, Any], has_masks: bool) -> dict[str, Any]:
+        """Convert one JSONL record into a HF row matching the ``_build_features`` schema.
+
+        Args:
+            record (dict[str, Any]): A single JSONL record.
+            has_masks (bool): Whether the dataset has masks.
+
+        Returns:
+            dict[str, Any]: A row keyed by the HF feature names.
+        """
+        row: dict[str, Any] = {
+            "image": os.path.join(self.target_path, str(record["umie_path"])),
+            "labels": self._flatten_labels(record.get("labels")),
+        }
+        if has_masks:
+            mask_path = record.get("mask_path")
+            row["mask"] = os.path.join(self.target_path, str(mask_path)) if mask_path else None
+
+        skip = {"umie_path", "mask_path", "labels"}
+        for key, value in record.items():
+            if key in skip:
+                continue
+            row[key] = "" if value is None else str(value)
+        return row
+
+    def _build_dataset_dict(
+        self,
+        records: list[dict[str, Any]],
+        features: Features,
+        has_masks: bool,
+    ) -> DatasetDict:
+        """Group records into a split-aware ``DatasetDict`` and cast to the feature schema.
+
+        When the records carry a ``split`` field, the resulting ``DatasetDict`` contains the
+        ``train`` / ``val`` / ``test`` splits that are actually present; otherwise all records
+        go into a single ``train`` split. The output is always a ``DatasetDict``.
+
+        Args:
+            records (list[dict[str, Any]]): All JSONL records.
+            features (Features): The feature schema to cast each split to.
+            has_masks (bool): Whether the dataset has masks.
+
+        Returns:
+            DatasetDict: The split-aware dataset, image/mask columns cast with ``Image()``.
+        """
+        rows = [self._record_to_row(record, has_masks) for record in records]
+
+        has_split = any(record.get("split") for record in records)
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        if has_split:
+            for record, row in zip(records, rows):
+                split = str(record.get("split") or DEFAULT_SPLIT)
+                grouped.setdefault(split, []).append(row)
+        else:
+            grouped[DEFAULT_SPLIT] = rows
+
+        # Emit known splits in canonical order first, then any unexpected extras deterministically.
+        ordered_splits = [s for s in SPLIT_ORDER if s in grouped]
+        ordered_splits += sorted(s for s in grouped if s not in SPLIT_ORDER)
+
+        splits = {split: Dataset.from_list(grouped[split], features=features) for split in ordered_splits}
+        return DatasetDict(splits)
+
+    def _modality_phase_breakdown(self, records: list[dict[str, Any]]) -> dict[str, int]:
+        """Count records per ``phase_name`` (modality / phase) for the dataset card.
+
+        Args:
+            records (list[dict[str, Any]]): All JSONL records.
+
+        Returns:
+            dict[str, int]: Record count keyed by phase name (deterministically ordered).
+        """
+        counts: dict[str, int] = {}
+        for record in records:
+            phase = str(record.get("phase_name") or "unknown")
+            counts[phase] = counts.get(phase, 0) + 1
+        return dict(sorted(counts.items()))
+
+    def _write_card(
+        self,
+        export_dir: str,
+        records: list[dict[str, Any]],
+        dataset_dict: DatasetDict,
+    ) -> None:
+        """Write a ``README.md`` dataset card describing license, provenance and breakdowns.
+
+        Args:
+            export_dir (str): Directory the dataset was saved to (card is written here).
+            records (list[dict[str, Any]]): All JSONL records (for the breakdowns).
+            dataset_dict (DatasetDict): The saved dataset (for per-split counts).
+        """
+        provenance = get_provenance(self.dataset_name)
+        total = sum(split.num_rows for split in dataset_dict.values())
+
+        lines: list[str] = [
+            f"# {self.dataset_uid}_{self.dataset_name}",
+            "",
+            "HuggingFace `datasets` export generated by the UMIE pipeline "
+            "(`ExportHuggingFace`, Task 30). Load it with "
+            "`datasets.load_from_disk(<this directory>)`.",
+            "",
+            "## License & source attribution",
+            "",
+            f"- **License:** {provenance.license}",
+            f"- **Source dataset:** {provenance.source_dataset}",
+        ]
+        if provenance.source_url:
+            lines.append(f"- **Source URL:** {provenance.source_url}")
+        if provenance.source_citation:
+            lines.append(f"- **Citation:** {provenance.source_citation}")
+        if provenance.redistributable is not None:
+            lines.append(f"- **Redistributable:** {provenance.redistributable}")
+
+        lines += [
+            "",
+            "## Record counts",
+            "",
+            f"- **Total records:** {total}",
+        ]
+        for split, dataset in dataset_dict.items():
+            lines.append(f"- **{split}:** {dataset.num_rows}")
+
+        lines += [
+            "",
+            "## Modality / phase breakdown",
+            "",
+        ]
+        for phase, count in self._modality_phase_breakdown(records).items():
+            lines.append(f"- **{phase}:** {count}")
+        lines.append("")
+
+        with open(os.path.join(export_dir, "README.md"), mode="w", encoding="utf-8") as card:
+            card.write("\n".join(lines))

--- a/src/steps/extract_dicom_metadata.py
+++ b/src/steps/extract_dicom_metadata.py
@@ -1,0 +1,297 @@
+"""Extract a configurable, de-identified set of DICOM header tags into the JSONL (Task 20).
+
+This optional, opt-in step enriches each dataset JSONL record with a small set of acquisition
+/ technical DICOM tags (never pixel data). It is additive: existing JSONL fields are never
+changed, only new keys are added (or, when ``metadata_config.metadata_sidecar`` is set, the
+extracted tags are written to a sidecar JSON under ``reports_dir()/dicom_metadata.json`` and
+the JSONL is left untouched).
+
+Which tags are stored
+---------------------
+The set of tags is configured per pipeline through ``metadata_config.dicom_tags`` (a list of
+DICOM keyword strings, e.g. ``["PatientAge", "PatientSex", "SliceThickness", "KVP",
+"XRayTubeCurrent", "Manufacturer", "ManufacturerModelName"]``). When ``dicom_tags`` is ``None``
+the step is a no-op and writes nothing.
+
+De-identification (default ON, ``metadata_config.deidentify``)
+--------------------------------------------------------------
+A module-level PHI denylist (``PHI_DENYLIST``) lists DICOM keywords that directly identify a
+patient (name, id, addresses, etc.). When ``deidentify`` is ``True`` (the default), these tags
+are NEVER written even if they are explicitly requested in ``dicom_tags``.
+
+Dates carry indirect PHI (they can re-identify a patient when combined with other records), so
+any requested DICOM *date* tag (keyword ending in ``Date``) is not written verbatim while
+de-identifying. Instead we apply a deterministic, per-study ``study_date_offset_days`` shift:
+the original date is parsed and shifted by a fixed, study-derived number of days, and only the
+resulting shifted date is stored (alongside the offset itself under
+``<TagName>_offset_days``) so relative timing between a patient's studies is preserved while the
+true calendar date is hidden. The offset is derived deterministically from the record's
+``study_id`` so the same study always shifts by the same amount and the shift is reproducible.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+import jsonlines
+import pydicom
+
+from base.step import BaseStep
+
+# Module-level PHI denylist: DICOM keywords that directly identify a patient. When
+# de-identification is on (the default) these are NEVER written, even if explicitly requested.
+PHI_DENYLIST: frozenset[str] = frozenset(
+    {
+        "PatientName",
+        "PatientID",
+        "PatientBirthDate",
+        "PatientBirthTime",
+        "PatientAddress",
+        "OtherPatientIDs",
+        "OtherPatientNames",
+        "OtherPatientIDsSequence",
+        "PatientTelephoneNumbers",
+        "PatientMotherBirthName",
+        "ReferringPhysicianName",
+        "PerformingPhysicianName",
+        "OperatorsName",
+        "InstitutionName",
+        "InstitutionAddress",
+        "IssuerOfPatientID",
+        "MilitaryRank",
+        "EthnicGroup",
+        "PatientReligiousPreference",
+        "PatientInsurancePlanCodeSequence",
+        "DeviceSerialNumber",
+        "AccessionNumber",
+    }
+)
+
+# How many days to clamp a deterministic per-study date shift to (kept small so relative
+# ordering between a patient's studies is preserved while the true calendar date is hidden).
+_MAX_DATE_OFFSET_DAYS: int = 30
+
+
+class ExtractDicomMetadata(BaseStep):
+    """Extract configured, de-identified DICOM header tags into additive JSONL fields (Task 20)."""
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Enrich the dataset JSONL (or a sidecar) with the configured DICOM tags.
+
+        No-op when ``metadata_config.dicom_tags`` is ``None``. Each JSONL record is mapped to a
+        source ``.dcm`` via ``source_paths.json`` if present, else by matching basename against
+        ``X``. Requested non-PHI tags are written; PHI tags are dropped and date tags are shifted
+        when ``deidentify`` is set. ``X`` is returned unchanged.
+
+        Args:
+            X (list): List of paths to the images (unchanged on return).
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        tags = self.metadata_config.dicom_tags
+        if not tags:
+            return X
+
+        print("Extracting DICOM metadata...")
+        source_paths = self._load_source_paths()
+        basename_index = self._index_by_basename(X)
+
+        if not os.path.exists(self.json_path):
+            return X
+
+        records: list[dict] = []
+        with jsonlines.open(self.json_path, mode="r") as reader:
+            for obj in reader:
+                records.append(obj)
+
+        extracted: dict[str, dict[str, Any]] = {}
+        for obj in records:
+            dcm_path = self._resolve_dcm_path(obj, source_paths, basename_index)
+            if dcm_path is None:
+                continue
+            metadata = self._extract_tags(dcm_path, list(tags), str(obj.get("study_id", "")))
+            if metadata:
+                extracted[obj["umie_path"]] = metadata
+
+        if self.metadata_config.metadata_sidecar:
+            self._write_sidecar(extracted)
+        else:
+            self._enrich_jsonl(records, extracted)
+
+        print(f"DICOM metadata extraction complete: enriched {len(extracted)} record(s).")
+        return X
+
+    def _load_source_paths(self) -> Optional[dict]:
+        """Load ``source_paths.json`` (``{umie_output_path: source_file_path}``) if present.
+
+        Returns:
+            Optional[dict]: The mapping, or ``None`` when the file does not exist.
+        """
+        path = os.path.join(self.target_path, "source_paths.json")
+        if os.path.exists(path):
+            with open(path) as handle:
+                return json.load(handle)
+        return None
+
+    def _index_by_basename(self, X: list) -> dict[str, str]:
+        """Build a ``{basename: path}`` index of source ``.dcm`` files in ``X``.
+
+        Args:
+            X (list): List of source/image paths.
+        Returns:
+            dict[str, str]: Mapping of file basename to the first matching path.
+        """
+        index: dict[str, str] = {}
+        for path in X:
+            base = os.path.basename(str(path))
+            index.setdefault(base, str(path))
+        return index
+
+    def _resolve_dcm_path(
+        self,
+        record: dict,
+        source_paths: Optional[dict],
+        basename_index: dict[str, str],
+    ) -> Optional[str]:
+        """Resolve a JSONL record to its source ``.dcm`` path.
+
+        Prefers ``source_paths.json`` (keyed by the absolute umie output path); falls back to
+        matching the record's ``umie_id`` basename against the source-file index.
+
+        Args:
+            record (dict): One JSONL record.
+            source_paths (Optional[dict]): The ``source_paths.json`` mapping, if loaded.
+            basename_index (dict[str, str]): ``{basename: source_path}`` fallback index.
+        Returns:
+            Optional[str]: An existing ``.dcm`` path, or ``None`` when none can be resolved.
+        """
+        if source_paths:
+            umie_abs = os.path.join(self.target_path, record["umie_path"])
+            candidate = source_paths.get(umie_abs) or source_paths.get(record["umie_path"])
+            if candidate and str(candidate).endswith(".dcm") and os.path.exists(candidate):
+                return str(candidate)
+
+        umie_id = record.get("umie_id", "")
+        base = os.path.splitext(umie_id)[0]
+        for key in (umie_id, f"{base}.dcm", base):
+            candidate = basename_index.get(key)
+            if candidate and str(candidate).endswith(".dcm") and os.path.exists(candidate):
+                return candidate
+        return None
+
+    def _extract_tags(self, dcm_path: str, tags: list[str], study_id: str) -> dict[str, Any]:
+        """Read the requested tags from one DICOM file, applying de-identification rules.
+
+        Args:
+            dcm_path (str): Path to the source ``.dcm`` file.
+            tags (list[str]): Requested DICOM keyword strings.
+            study_id (str): The record's study id, used to derive a deterministic date offset.
+        Returns:
+            dict[str, Any]: Mapping of stored tag name to value (PHI tags omitted).
+        """
+        try:
+            dataset = pydicom.dcmread(dcm_path, stop_before_pixels=True)
+        except Exception:
+            return {}
+
+        deidentify = self.metadata_config.deidentify
+        result: dict[str, Any] = {}
+        for tag in tags:
+            if deidentify and tag in PHI_DENYLIST:
+                # Never write a denylisted tag when de-identifying, even if requested.
+                continue
+            if tag not in dataset:
+                continue
+            value = dataset.get(tag)
+            if value is None:
+                continue
+            if tag.endswith("Date") and deidentify:
+                shifted = self._shift_date(str(value), study_id)
+                if shifted is not None:
+                    result[tag] = shifted
+                    result[f"{tag}_offset_days"] = self._date_offset_days(study_id)
+                continue
+            result[tag] = self._to_jsonable(value)
+        return result
+
+    @staticmethod
+    def _to_jsonable(value: Any) -> Any:
+        """Coerce a pydicom value into a JSON-serialisable scalar/list.
+
+        Args:
+            value (Any): Raw pydicom element value.
+        Returns:
+            Any: A JSON-serialisable representation (str, number, bool, or list thereof).
+        """
+        if isinstance(value, (str, int, float, bool)):
+            return value
+        try:
+            return [ExtractDicomMetadata._to_jsonable(item) for item in value]
+        except TypeError:
+            return str(value)
+
+    @staticmethod
+    def _date_offset_days(study_id: str) -> int:
+        """Return a deterministic per-study date offset in ``[-MAX, +MAX]`` days.
+
+        Derived from the study id so the same study always shifts by the same amount (relative
+        timing between a patient's studies is preserved) and the shift is reproducible.
+
+        Args:
+            study_id (str): The record's study id.
+        Returns:
+            int: The signed day offset.
+        """
+        digest = sum(ord(char) for char in study_id) if study_id else 0
+        span = 2 * _MAX_DATE_OFFSET_DAYS + 1
+        return (digest % span) - _MAX_DATE_OFFSET_DAYS
+
+    def _shift_date(self, raw: str, study_id: str) -> Optional[str]:
+        """Shift a ``YYYYMMDD`` DICOM date by the study's deterministic offset.
+
+        Args:
+            raw (str): The raw DICOM date value.
+            study_id (str): The record's study id (drives the offset).
+        Returns:
+            Optional[str]: The shifted ``YYYYMMDD`` date, or ``None`` if ``raw`` is unparseable.
+        """
+        raw = raw.strip()
+        try:
+            parsed = datetime.strptime(raw, "%Y%m%d")
+        except ValueError:
+            return None
+        shifted = parsed + timedelta(days=self._date_offset_days(study_id))
+        return shifted.strftime("%Y%m%d")
+
+    def _enrich_jsonl(self, records: list[dict], extracted: dict[str, dict[str, Any]]) -> None:
+        """Rewrite the JSONL in place, adding a ``dicom_metadata`` field to matching records.
+
+        Existing keys and record order are preserved; only the additive ``dicom_metadata`` key
+        is added (records without extracted metadata are written back unchanged).
+
+        Args:
+            records (list[dict]): All JSONL records, in original order.
+            extracted (dict[str, dict[str, Any]]): ``{umie_path: metadata}`` mapping.
+        """
+        with jsonlines.open(self.json_path, mode="w") as writer:
+            for obj in records:
+                metadata = extracted.get(obj["umie_path"])
+                if metadata:
+                    obj["dicom_metadata"] = metadata
+                writer.write(obj)
+
+    def _write_sidecar(self, extracted: dict[str, dict[str, Any]]) -> None:
+        """Write the extracted metadata to a sidecar JSON under the reports dir.
+
+        Args:
+            extracted (dict[str, dict[str, Any]]): ``{umie_path: metadata}`` mapping.
+        """
+        path = os.path.join(self.reports_dir(), "dicom_metadata.json")
+        with open(path, "w") as handle:
+            json.dump(extracted, handle, indent=2)

--- a/src/steps/merge_masks.py
+++ b/src/steps/merge_masks.py
@@ -1,0 +1,159 @@
+"""Merge several single-structure mask PNGs for one image into one multi-class mask."""
+
+import glob
+import json
+import os
+from collections import defaultdict
+from typing import Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+
+
+class MergeMasks(BaseStep):
+    """Merge several single-structure mask PNGs for one image into one multi-class mask.
+
+    Each source mask labels a different anatomical structure with its own
+    ``config/masks.py`` colour. For every UMIE image that has more than one mask written
+    under the dataset's ``Masks`` folders, the masks are combined into a single multi-class
+    mask. Pixels that are already non-zero in an earlier mask (overlaps) are resolved
+    according to ``self.format_config.overlap_policy`` (``report`` | ``first`` | ``last`` |
+    ``priority``). An overlaps summary is always written to
+    ``reports_dir()/mask_merge_report.json``. UMIE ids and folder layout are never changed.
+    """
+
+    def transform(
+        self,
+        X: list,  # img_paths
+    ) -> list:
+        """Merge multiple per-structure masks of each image into one multi-class mask.
+
+        Masks are grouped by their output basename (the UMIE id) within each phase's
+        ``Masks`` folder. A group with several distinct mask arrays is merged with the
+        configured overlap policy and written back over the group's masks. A per-group
+        overlap summary is written to ``reports_dir()/mask_merge_report.json``. ``X`` is
+        returned unchanged.
+
+        Args:
+            X (list): List of paths to the images.
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        print("Merging masks...")
+        policy = self.format_config.overlap_policy
+        priority = self.format_config.merge_priority
+        groups = self._group_mask_paths()
+        report: dict = {
+            "overlap_policy": policy,
+            "merge_priority": priority,
+            "groups": [],
+        }
+        for group_key, mask_paths in sorted(groups.items()):
+            if len(mask_paths) < 2:
+                continue
+            arrays = [array for array in (self._read_mask(path) for path in mask_paths) if array is not None]
+            if len(arrays) < 2:
+                continue
+            merged, overlap_count = self._merge(arrays, policy, priority)
+            for path in mask_paths:
+                cv2.imwrite(path, merged)
+            report["groups"].append(
+                {
+                    "group": group_key,
+                    "masks": [self.get_path_without_target_path(path) for path in mask_paths],
+                    "overlap_pixel_count": overlap_count,
+                }
+            )
+        self._write_report(report)
+        print(f"Mask merge complete: {len(report['groups'])} group(s) merged.")
+        return X
+
+    def _group_mask_paths(self) -> dict[str, list[str]]:
+        """Group output mask PNG paths by their basename (the UMIE id).
+
+        Returns:
+            dict[str, list[str]]: Mapping of mask basename to the sorted paths sharing it.
+        """
+        # Single-structure masks for the same image share a UMIE-id basename; they live either
+        # directly in a phase's Masks folder or in per-structure subfolders beneath it. Match
+        # both by globbing every PNG at any depth under a Masks folder.
+        pattern = os.path.join(self.dataset_root, f"**/{self.mask_folder_name}/**/*.png")
+        groups: dict[str, list[str]] = defaultdict(list)
+        for path in glob.glob(pattern, recursive=True):
+            groups[os.path.basename(path)].append(path)
+        return {key: sorted(value) for key, value in groups.items()}
+
+    def _read_mask(self, path: str) -> Optional[np.ndarray]:
+        """Read a single-channel mask PNG into a numpy array, or None if unreadable.
+
+        Args:
+            path (str): Path to the mask PNG.
+        Returns:
+            Optional[np.ndarray]: The mask array, or None when it cannot be read.
+        """
+        mask = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+        return mask
+
+    @staticmethod
+    def _merge(
+        mask_arrays: list[np.ndarray],
+        policy: str,
+        priority: Optional[list],
+    ) -> tuple[np.ndarray, int]:
+        """Merge mask arrays into one and resolve overlaps per the chosen policy.
+
+        ``report`` and ``first`` both keep the colour written by the earlier mask on an
+        overlapping pixel; ``last`` keeps the colour from the later mask; ``priority`` keeps
+        the colour appearing earlier in ``priority`` (descending priority). Overlap pixels are
+        counted wherever two or more input masks are simultaneously non-zero.
+
+        Args:
+            mask_arrays (list[np.ndarray]): Single-structure masks for the same image.
+            policy (str): One of ``report`` | ``first`` | ``last`` | ``priority``.
+            priority (Optional[list]): Mask colours in descending priority (policy="priority").
+        Returns:
+            tuple[np.ndarray, int]: The merged mask and the overlapping pixel count.
+        """
+        first = mask_arrays[0]
+        merged = np.zeros_like(first)
+        occupied = np.zeros(first.shape[:2], dtype=bool)
+        overlap = np.zeros(first.shape[:2], dtype=bool)
+
+        priority_rank = {int(color): rank for rank, color in enumerate(priority or [])}
+        # Higher number == better-established colour already placed; default rank for the
+        # "priority" policy keeps unknown colours below any listed colour.
+        worst_rank = len(priority_rank) + 1
+        current_rank = np.full(first.shape[:2], worst_rank, dtype=np.int64)
+
+        for mask in mask_arrays:
+            present = mask > 0
+            overlap |= occupied & present
+
+            if policy == "last":
+                write = present
+            elif policy == "priority":
+                incoming_rank = np.full(first.shape[:2], worst_rank, dtype=np.int64)
+                for color, rank in priority_rank.items():
+                    incoming_rank[mask == color] = rank
+                # Lower rank value == higher priority; write where empty or strictly better.
+                write = present & (~occupied | (incoming_rank < current_rank))
+                current_rank = np.where(write, incoming_rank, current_rank)
+            else:  # "report" and "first" keep the earlier colour
+                write = present & ~occupied
+
+            merged[write] = mask[write]
+            occupied |= present
+
+        return merged, int(np.count_nonzero(overlap))
+
+    def _write_report(self, report: dict) -> None:
+        """Write the mask-merge overlaps summary to JSON under the reports dir.
+
+        Args:
+            report (dict): The accumulated merge report.
+        """
+        report_path = os.path.join(self.reports_dir(), "mask_merge_report.json")
+        with open(report_path, "w") as handle:
+            json.dump(report, handle, indent=2)

--- a/src/steps/normalize_spacing.py
+++ b/src/steps/normalize_spacing.py
@@ -1,0 +1,137 @@
+"""Optional, opt-in pixel-spacing normalization for NIfTI volumes (Theme E, Task 16)."""
+
+import glob
+import os
+from typing import Optional
+
+import jsonlines
+import nibabel as nib  # type: ignore[import-untyped]
+import numpy as np
+from scipy.ndimage import zoom  # type: ignore[import-untyped]
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class NormalizeSpacing(BaseStep):
+    """Resample NIfTI volumes to a target voxel spacing (images bilinear, masks nearest)."""
+
+    def transform(self, X: list) -> list:
+        """Resample image and mask volumes to ``self.preprocessing.target_spacing_mm``.
+
+        Primary path is 3D NIfTI volumes: the current zooms are read from the header, the data is
+        resampled with ``scipy.ndimage.zoom`` (order=1 for images, order=0 for masks so no new
+        label values appear), the affine scale is updated, and the new spacing is recorded in the
+        JSONL as an additive ``pixel_spacing_mm`` field. 2D PNGs carry no spacing source and are
+        skipped (no-op). No-op when ``target_spacing_mm`` is None.
+
+        Args:
+            X (list): List of paths to the images.
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        target = self.preprocessing.target_spacing_mm
+        if target is None or self.output_mode != OutputMode.VOLUMES_3D:
+            # No spacing source for 2D PNG output; documented skip.
+            return X
+
+        target_spacing = tuple(float(v) for v in target)
+        new_spacings: dict[str, list[float]] = {}
+
+        image_paths = glob.glob(
+            os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.nii.gz"), recursive=True
+        )
+        mask_paths = glob.glob(os.path.join(self.dataset_root, f"**/{self.mask_folder_name}/*.nii.gz"), recursive=True)
+        print("Normalizing voxel spacing...")
+        for image_path in image_paths:
+            new_spacings[image_path] = self._resample(image_path, target_spacing, is_mask=False)
+        for mask_path in mask_paths:
+            self._resample(mask_path, target_spacing, is_mask=True)
+
+        self._record_spacing(new_spacings)
+        return X
+
+    def _resample(self, volume_path: str, target_spacing: tuple, is_mask: bool) -> list[float]:
+        """Resample a single NIfTI volume to ``target_spacing`` and overwrite it in place.
+
+        Args:
+            volume_path (str): Path to the ``.nii.gz`` volume.
+            target_spacing (tuple): Desired voxel spacing in mm (one value per spatial axis).
+            is_mask (bool): If True use nearest-neighbour (order=0) so no new labels appear.
+
+        Returns:
+            list[float]: The resulting voxel spacing actually written to the header.
+        """
+        nii = nib.load(volume_path)
+        data = np.asarray(nii.get_fdata())  # type: ignore[attr-defined]
+        current_spacing = tuple(float(z) for z in nii.header.get_zooms()[: data.ndim])  # type: ignore[attr-defined]
+        factors = tuple(current_spacing[i] / target_spacing[i] for i in range(data.ndim))
+
+        order = 0 if is_mask else 1
+        resampled = zoom(data, factors, order=order)
+        # Masks keep their original integer dtype so order=0 introduces no new label values; image
+        # data may stay floating-point.
+        out_dtype = nii.get_data_dtype() if is_mask else resampled.dtype  # type: ignore[attr-defined]
+        resampled = resampled.astype(out_dtype)
+
+        affine = np.array(nii.affine, dtype=np.float64)  # type: ignore[attr-defined]
+        new_affine = affine.copy()
+        # Rescale each spatial column of the affine so the new spacing is encoded, preserving
+        # the rotation/orientation direction of each axis.
+        for axis in range(min(3, data.ndim)):
+            column = affine[:3, axis]
+            norm = float(np.linalg.norm(column))
+            if norm != 0:
+                new_affine[:3, axis] = column / norm * target_spacing[axis]
+
+        new_header = nii.header.copy()  # type: ignore[attr-defined]
+        new_header.set_data_dtype(out_dtype)  # type: ignore[attr-defined]
+        # Clear any intensity scaling so the resampled values are written verbatim (otherwise a
+        # stale scl_slope/scl_inter from the source header would re-quantize the data on save).
+        new_header.set_slope_inter(None, None)  # type: ignore[attr-defined]
+        new_header.set_zooms(tuple(target_spacing[: data.ndim]))  # type: ignore[attr-defined]
+        out = nib.Nifti1Image(resampled, affine=new_affine, header=new_header)  # type: ignore[no-untyped-call]
+        nib.save(out, volume_path)
+        return [float(z) for z in out.header.get_zooms()[: data.ndim]]  # type: ignore[no-untyped-call]
+
+    def _record_spacing(self, new_spacings: dict[str, list[float]]) -> None:
+        """Add an additive ``pixel_spacing_mm`` field to matching JSONL records.
+
+        Existing fields are never overwritten; records whose volume was not resampled are left
+        unchanged. Does nothing when the JSONL file does not yet exist.
+
+        Args:
+            new_spacings (dict[str, list[float]]): Map of absolute image path -> new spacing.
+        """
+        if not os.path.exists(self.json_path) or not new_spacings:
+            return
+        by_relpath = {self.get_path_without_target_path(path): spacing for path, spacing in new_spacings.items()}
+        with jsonlines.open(self.json_path, mode="r") as reader:
+            records = list(reader)
+        for record in records:
+            spacing = self._lookup_spacing(record, by_relpath)
+            if spacing is not None and "pixel_spacing_mm" not in record:
+                record["pixel_spacing_mm"] = spacing
+        with jsonlines.open(self.json_path, mode="w") as writer:
+            for record in records:
+                writer.write(record)
+
+    @staticmethod
+    def _lookup_spacing(record: dict, by_relpath: dict[str, list[float]]) -> Optional[list[float]]:
+        """Find the new spacing for a JSONL record by its ``umie_path`` (basename fallback).
+
+        Args:
+            record (dict): A single JSONL record.
+            by_relpath (dict[str, list[float]]): Map of relative image path -> new spacing.
+
+        Returns:
+            Optional[list[float]]: The matching spacing, or None when no volume matches.
+        """
+        umie_path = record.get("umie_path")
+        if umie_path in by_relpath:
+            return by_relpath[umie_path]
+        for relpath, spacing in by_relpath.items():
+            if umie_path is not None and os.path.basename(relpath) == os.path.basename(str(umie_path)):
+                return spacing
+        return None

--- a/src/steps/resize_images.py
+++ b/src/steps/resize_images.py
@@ -1,0 +1,109 @@
+"""Optional, opt-in image resizing keeping the paired mask aligned (Theme E, Task 17)."""
+
+import glob
+import os
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class ResizeImages(BaseStep):
+    """Resize images to a target (h, w) with a chosen strategy; masks use nearest-neighbour."""
+
+    def transform(self, X: list) -> list:
+        """Resize every image PNG to ``self.preprocessing.target_size`` and align its mask.
+
+        Images are resampled bilinearly (``cv2.INTER_LINEAR``); the paired mask is resampled
+        nearest-neighbour (``cv2.INTER_NEAREST``) with the SAME geometry so it stays pixel-aligned
+        and gains no new label values. No-op when ``target_size`` is None. Only runs in 2D mode.
+
+        Args:
+            X (list): List of paths to the images.
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        target_size = self.preprocessing.target_size
+        if target_size is None or self.output_mode == OutputMode.VOLUMES_3D:
+            return X
+
+        target = (int(target_size[0]), int(target_size[1]))
+        strategy = self.preprocessing.resize_strategy
+        image_paths = glob.glob(os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.png"), recursive=True)
+        print("Resizing images...")
+        for image_path in image_paths:
+            image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+            if image is None:
+                continue
+            cv2.imwrite(image_path, self._resize(image, target, strategy, cv2.INTER_LINEAR))
+
+            mask_path = image_path.replace(
+                os.sep + self.image_folder_name + os.sep, os.sep + self.mask_folder_name + os.sep
+            )
+            if os.path.exists(mask_path):
+                mask = cv2.imread(mask_path, cv2.IMREAD_UNCHANGED)
+                if mask is not None:
+                    cv2.imwrite(mask_path, self._resize(mask, target, strategy, cv2.INTER_NEAREST))
+        return X
+
+    def _resize(self, image: np.ndarray, target: tuple, strategy: str, interpolation: int) -> np.ndarray:
+        """Resize one array to ``target`` (height, width) using the requested strategy.
+
+        Args:
+            image (np.ndarray): Source image or mask array.
+            target (tuple): Desired (height, width).
+            strategy (str): One of ``pad``, ``crop``, ``letterbox``, ``stretch``.
+            interpolation (int): cv2 interpolation flag (bilinear for images, nearest for masks).
+
+        Returns:
+            np.ndarray: The resized array with shape ``target`` (plus any channel axis).
+        """
+        target_h, target_w = target
+        if strategy == "stretch":
+            # Ignore aspect ratio: scale straight to the target.
+            return cv2.resize(image, (target_w, target_h), interpolation=interpolation)
+        if strategy == "letterbox":
+            # Scale to fit inside the target preserving aspect ratio, then zero-pad.
+            scale = min(target_h / image.shape[0], target_w / image.shape[1])
+            resized = self._scale(image, scale, interpolation)
+            return self._fit_canvas(resized, target_h, target_w)
+        if strategy == "pad":
+            # No scaling: center on a zero canvas, center-cropping any axis that overflows.
+            return self._fit_canvas(image, target_h, target_w)
+        if strategy == "crop":
+            # Scale to cover the target preserving aspect ratio, then center-crop the overflow.
+            scale = max(target_h / image.shape[0], target_w / image.shape[1])
+            resized = self._scale(image, scale, interpolation)
+            return self._fit_canvas(resized, target_h, target_w)
+        raise ValueError(f"Unknown resize strategy '{strategy}'. Choose from pad, crop, letterbox, stretch.")
+
+    @staticmethod
+    def _scale(image: np.ndarray, scale: float, interpolation: int) -> np.ndarray:
+        """Uniformly scale an image by ``scale`` (at least 1px per axis), preserving aspect ratio."""
+        new_h = max(1, int(round(image.shape[0] * scale)))
+        new_w = max(1, int(round(image.shape[1] * scale)))
+        return cv2.resize(image, (new_w, new_h), interpolation=interpolation)
+
+    @staticmethod
+    def _fit_canvas(image: np.ndarray, target_h: int, target_w: int) -> np.ndarray:
+        """Center the image on a ``target_h`` x ``target_w`` zero canvas, cropping any overflow.
+
+        Always returns an array of exactly the target spatial dimensions (plus any channel axis),
+        so every strategy yields the requested size regardless of the source size.
+        """
+        source_h, source_w = image.shape[:2]
+        crop_h = min(source_h, target_h)
+        crop_w = min(source_w, target_w)
+        src_top = (source_h - crop_h) // 2
+        src_left = (source_w - crop_w) // 2
+        cropped = image[src_top : src_top + crop_h, src_left : src_left + crop_w]
+
+        canvas_shape = (target_h, target_w) + image.shape[2:]
+        canvas = np.zeros(canvas_shape, dtype=image.dtype)
+        dst_top = (target_h - crop_h) // 2
+        dst_left = (target_w - crop_w) // 2
+        canvas[dst_top : dst_top + crop_h, dst_left : dst_left + crop_w] = cropped
+        return canvas

--- a/src/steps/skip_processed.py
+++ b/src/steps/skip_processed.py
@@ -1,0 +1,75 @@
+"""Filter out source files that have already been converted, to resume an interrupted run.
+
+This optional, opt-in step (Theme H, Task 28) implements incremental processing / resume.
+Given the list ``X`` of SOURCE file paths, it drops any source whose expected UMIE output
+(``self.get_umie_img_path(src)``) already exists on disk, returning only the not-yet-processed
+sources. An interrupted run can therefore be re-run and will only process the remainder.
+
+Because it skips a source only when that source's *correct* output already exists, a resumed
+run is byte-identical to a clean run: nothing already-correct is touched, and everything else
+is processed exactly as before.
+
+If :attr:`~base.pipeline.ExportConfig.force_reprocess` is ``True``, the step returns ``X``
+unchanged so the whole dataset is reprocessed.
+
+Placement / interaction with ``DeleteOldPreprocessedData``:
+    ``DeleteOldPreprocessedData`` wipes the existing outputs; once it has run there are no
+    outputs to skip, so a full reprocess naturally follows. Place ``SkipProcessed`` AFTER
+    ``get_file_paths`` (it needs the full source list) and AFTER any delete-old step (so it
+    never skips files whose outputs were just deleted). With both steps active, the
+    delete-old step always wins and the resume optimisation simply becomes a no-op.
+
+Robustness:
+    ``get_umie_img_path`` can raise (e.g. a source whose phase id is not in the configured
+    phases). Such sources are treated as not-yet-processed and kept in ``X`` so they flow on
+    to the normal conversion steps rather than being silently dropped.
+"""
+
+import os
+
+from base.step import BaseStep
+
+
+class SkipProcessed(BaseStep):
+    """Drop sources whose UMIE output already exists, so an interrupted run resumes cleanly."""
+
+    #: Treat a zero-byte output as not-yet-processed (a truncated / interrupted write).
+    _REQUIRE_NONZERO_SIZE = True
+
+    def transform(self, X: list) -> list:
+        """Return only the sources in ``X`` that still need processing.
+
+        Args:
+            X (list): List of SOURCE file paths.
+
+        Returns:
+            list: The subset of ``X`` whose UMIE output does not yet exist (or all of
+            ``X`` when ``force_reprocess`` is set).
+        """
+        if self.export_config.force_reprocess:
+            return X
+        return [src for src in X if not self._is_already_processed(src)]
+
+    def _is_already_processed(self, src: str) -> bool:
+        """Return whether ``src`` already has a valid UMIE output on disk.
+
+        A source counts as processed only when its mapped output path exists and (when
+        :attr:`_REQUIRE_NONZERO_SIZE`) is non-empty. If the path cannot be mapped (e.g. an
+        unmapped phase makes ``get_umie_img_path`` raise) the source is treated as
+        not-yet-processed so it is kept for normal processing.
+
+        Args:
+            src (str): A SOURCE file path.
+
+        Returns:
+            bool: ``True`` if a valid output already exists, else ``False``.
+        """
+        try:
+            output_path = self.get_umie_img_path(src)
+        except Exception:
+            return False
+        if not os.path.exists(output_path):
+            return False
+        if self._REQUIRE_NONZERO_SIZE and os.path.getsize(output_path) == 0:
+            return False
+        return True

--- a/src/steps/standardize_bit_depth.py
+++ b/src/steps/standardize_bit_depth.py
@@ -1,0 +1,62 @@
+"""Optional, opt-in bit-depth standardization for image PNGs only (Theme E, Task 18)."""
+
+import glob
+import os
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+from base.step import BaseStep
+from constants import OutputMode
+
+
+class StandardizeBitDepth(BaseStep):
+    """Convert images to a target bit depth (8 or 16) without clipping or wraparound."""
+
+    def transform(self, X: list) -> list:
+        """Standardize every image PNG to ``self.preprocessing.target_bit_depth``.
+
+        16->8 divides by 256 (drops the low byte, no clip/overflow); 8->16 multiplies by 256.
+        Images already at the target depth are skipped. No-op when ``target_bit_depth`` is None.
+        Masks are never touched. Only runs in 2D (PNG) output mode.
+
+        Args:
+            X (list): List of paths to the images.
+
+        Returns:
+            list: The unchanged list of image paths.
+        """
+        target = self.preprocessing.target_bit_depth
+        if target is None or self.output_mode == OutputMode.VOLUMES_3D:
+            return X
+        if target not in (8, 16):
+            raise ValueError(f"target_bit_depth must be 8 or 16, got {target}.")
+
+        image_paths = glob.glob(os.path.join(self.dataset_root, f"**/{self.image_folder_name}/*.png"), recursive=True)
+        print(f"Standardizing image bit depth to {target}-bit...")
+        for image_path in image_paths:
+            self._standardize(image_path, target)
+        return X
+
+    def _standardize(self, image_path: str, target: int) -> None:
+        """Convert a single image to the target bit depth, logging any conversion performed.
+
+        Args:
+            image_path (str): Path to the image PNG.
+            target (int): Target bit depth (8 or 16).
+        """
+        image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        if image is None:
+            return
+        current = 16 if image.dtype == np.uint16 else 8
+        if current == target:
+            return
+        converted: np.ndarray
+        if target == 8:
+            # 16->8: integer divide by 256 keeps the high byte; no clipping/overflow possible.
+            converted = (image.astype(np.uint16) // 256).astype(np.uint8)
+        else:
+            # 8->16: multiply by 256 to spread values across the wider range.
+            converted = (image.astype(np.uint16) * 256).astype(np.uint16)
+        print(f"Converting {os.path.basename(image_path)} from {current}-bit to {target}-bit")
+        cv2.imwrite(image_path, converted)

--- a/src/steps/validate_dicom_metadata.py
+++ b/src/steps/validate_dicom_metadata.py
@@ -1,0 +1,107 @@
+"""Validate required DICOM metadata tags on source files before conversion."""
+
+import json
+import os
+
+import pydicom
+
+from base.step import BaseStep
+
+
+class ValidateDicomMetadata(BaseStep):
+    """Validate required DICOM metadata tags on source files before conversion."""
+
+    def transform(
+        self,
+        X: list,  # source file paths
+    ) -> list:
+        """Check source DICOM files against ``quality.required_dicom_tags`` and report issues.
+
+        Each ``.dcm`` path in ``X`` is read with pydicom and validated against
+        ``quality.required_dicom_tags`` (``{tag_name: expected_value_or_None}``; ``None`` means
+        the tag must merely be present, a value means it must equal). Files with missing or
+        unexpected tags are written to a JSON report. When ``quality.exclude_invalid_dicom`` is
+        set, invalid files are dropped from the returned list; otherwise ``X`` is returned
+        unchanged. UMIE ids are never altered.
+
+        Args:
+            X (list): List of source file paths.
+        Returns:
+            list: ``X`` unchanged, or with invalid DICOM files removed when configured to drop.
+        """
+        required = self.quality.required_dicom_tags
+        if not required:
+            return X
+
+        print("Validating DICOM metadata...")
+        invalid: dict = {}
+        for path in X:
+            if not str(path).endswith(".dcm"):
+                continue
+            issues = self._validate_file(path, required)
+            if issues:
+                invalid[self._report_key(path)] = issues
+
+        self._write_report(invalid, required)
+        print(f"DICOM metadata validation complete: {len(invalid)} invalid file(s).")
+
+        if self.quality.exclude_invalid_dicom and invalid:
+            invalid_keys = set(invalid.keys())
+            return [path for path in X if self._report_key(path) not in invalid_keys]
+        return X
+
+    def _report_key(self, path: str) -> str:
+        """Return a stable identifier for a source path used as a report key.
+
+        Args:
+            path (str): Source file path.
+        Returns:
+            str: Path relative to the source dir when possible, else the original path.
+        """
+        try:
+            return os.path.relpath(path, self.source_path)
+        except ValueError:
+            return path
+
+    def _validate_file(self, path: str, required: dict) -> list:
+        """Validate one DICOM file and return a list of issue descriptions.
+
+        Args:
+            path (str): Path to the ``.dcm`` file.
+            required (dict): ``{tag_name: expected_value_or_None}`` requirements.
+        Returns:
+            list: Issue dicts, empty when the file satisfies every requirement.
+        """
+        try:
+            dataset = pydicom.dcmread(path, stop_before_pixels=True)
+        except Exception as error:
+            return [{"tag": None, "issue": "unreadable", "detail": str(error)}]
+
+        issues = []
+        for tag_name, expected in required.items():
+            if tag_name not in dataset:
+                issues.append({"tag": tag_name, "issue": "missing"})
+                continue
+            if expected is not None:
+                actual = dataset.get(tag_name)
+                if str(actual) != str(expected):
+                    issues.append(
+                        {"tag": tag_name, "issue": "unexpected_value", "expected": expected, "actual": str(actual)}
+                    )
+        return issues
+
+    def _write_report(self, invalid: dict, required: dict) -> None:
+        """Write the DICOM metadata report to JSON under the reports dir.
+
+        Args:
+            invalid (dict): Mapping of report key to its list of issues.
+            required (dict): The required-tag configuration that was checked.
+        """
+        report = {
+            "required_dicom_tags": {key: value for key, value in required.items()},
+            "exclude_invalid_dicom": self.quality.exclude_invalid_dicom,
+            "invalid": invalid,
+        }
+        report_path = os.path.join(self.reports_dir(), "dicom_metadata_report.json")
+        with open(report_path, "w") as handle:
+            json.dump(report, handle, indent=2)

--- a/testing/tests/test_add_provenance.py
+++ b/testing/tests/test_add_provenance.py
@@ -1,0 +1,89 @@
+"""Unit tests for AddProvenance: additive license / source-attribution JSONL fields."""
+
+import os
+import tempfile
+
+import jsonlines
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.add_provenance import AddProvenance
+
+
+def _make_ctx(tmp: str, dataset_name: str = "synthetic") -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name=dataset_name, phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_jsonl(tmp: str, dataset_name: str) -> str:
+    """Write a single-record JSONL for the given dataset name."""
+    dataset_dir = os.path.join(tmp, f"99_{dataset_name}")
+    os.makedirs(dataset_dir, exist_ok=True)
+    jsonl_path = os.path.join(dataset_dir, f"99_{dataset_name}.jsonl")
+    with jsonlines.open(jsonl_path, mode="w") as writer:
+        writer.write(
+            {
+                "umie_path": f"99_{dataset_name}/CT/Images/99_0_1_0.png",
+                "dataset_name": dataset_name,
+                "dataset_uid": "99",
+                "phase_name": "CT",
+                "comparative": "",
+                "study_id": "1",
+                "umie_id": "99_0_1_0.png",
+                "mask_path": "",
+                "labels": [],
+                "source_labels": [],
+            }
+        )
+    return jsonl_path
+
+
+def _read_records(jsonl_path: str) -> list:
+    """Read all JSONL records from a path."""
+    with jsonlines.open(jsonl_path, mode="r") as reader:
+        return list(reader)
+
+
+def test_known_dataset_populated_from_provenance():
+    """For a known dataset_name, license/source_dataset come from config.provenance.PROVENANCE."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp, "kits23")
+        AddProvenance(_make_ctx(tmp, "kits23")).transform([])
+
+        record = _read_records(jsonl_path)[0]
+        assert record["license"] == "CC-BY-NC-SA-4.0"
+        assert "KiTS23" in record["source_dataset"]
+        # Existing fields preserved.
+        assert record["umie_id"] == "99_0_1_0.png"
+
+
+def test_unknown_dataset_falls_back_to_unknown():
+    """An unknown dataset_name falls back to the DEFAULT_PROVENANCE 'unknown' values."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp, "not_a_real_dataset")
+        AddProvenance(_make_ctx(tmp, "not_a_real_dataset")).transform([])
+
+        record = _read_records(jsonl_path)[0]
+        assert record["license"] == "unknown"
+        assert record["source_dataset"] == "unknown"
+
+
+def test_noop_when_disabled():
+    """When add_provenance is False the step is a no-op and adds no fields."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp, "kits23")
+        ctx = _make_ctx(tmp, "kits23")
+        ctx.metadata.add_provenance = False
+        AddProvenance(ctx).transform([])
+
+        record = _read_records(jsonl_path)[0]
+        assert "license" not in record

--- a/testing/tests/test_apply_clahe.py
+++ b/testing/tests/test_apply_clahe.py
@@ -1,0 +1,70 @@
+"""Unit tests for the ApplyClahe step using small synthetic PNGs (no external data)."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.apply_clahe import ApplyClahe
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext rooted at ``tmp`` (synthetic dataset uid 99)."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_image(tmp: str, image: np.ndarray) -> str:
+    """Write a synthetic image into the UMIE folder layout and return its path."""
+    image_dir = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    os.makedirs(image_dir, exist_ok=True)
+    image_path = os.path.join(image_dir, "99_0_001_x.png")
+    cv2.imwrite(image_path, image)
+    return image_path
+
+
+def _low_contrast_image() -> np.ndarray:
+    """Return a low-contrast 8-bit gradient image CLAHE will visibly alter."""
+    base = np.linspace(100, 140, 64, dtype=np.uint8)
+    return np.tile(base, (64, 1))
+
+
+def test_disabled_is_byte_identical_no_op():
+    """When clahe_enabled is False the output file is byte-identical (no write)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image_path = _write_image(tmp, _low_contrast_image())
+        before = open(image_path, "rb").read()
+
+        ctx = _make_ctx(tmp)
+        assert ctx.preprocessing.clahe_enabled is False
+        ApplyClahe(ctx).transform([image_path])
+
+        assert open(image_path, "rb").read() == before
+
+
+def test_enabled_produces_valid_png_and_changes_low_contrast():
+    """When enabled, output stays a readable uint8 PNG and differs for a low-contrast input."""
+    with tempfile.TemporaryDirectory() as tmp:
+        original = _low_contrast_image()
+        image_path = _write_image(tmp, original)
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.clahe_enabled = True
+        ApplyClahe(ctx).transform([image_path])
+
+        out = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        assert out is not None  # still a valid, readable PNG
+        assert out.dtype == np.uint8
+        assert out.shape == original.shape
+        assert not np.array_equal(out, original)  # contrast was enhanced

--- a/testing/tests/test_apply_windowing.py
+++ b/testing/tests/test_apply_windowing.py
@@ -1,0 +1,104 @@
+"""Unit tests for the ApplyWindowing step using small synthetic PNGs (no external data)."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.apply_windowing import WINDOW_PRESETS, ApplyWindowing
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext rooted at ``tmp`` (synthetic CT dataset uid 99)."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_dataset(tmp: str, image: np.ndarray, mask: np.ndarray) -> tuple[str, str]:
+    """Write a synthetic image+mask pair into the UMIE folder layout; return their paths."""
+    image_dir = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    mask_dir = os.path.join(tmp, "99_synthetic", "CT", "Masks")
+    os.makedirs(image_dir, exist_ok=True)
+    os.makedirs(mask_dir, exist_ok=True)
+    image_path = os.path.join(image_dir, "99_0_001_x.png")
+    mask_path = os.path.join(mask_dir, "99_0_001_x.png")
+    cv2.imwrite(image_path, image)
+    cv2.imwrite(mask_path, mask)
+    return image_path, mask_path
+
+
+def test_preset_windowing_maps_known_values():
+    """A brain preset (40, 80) -> window [0, 80]; values map linearly to 0-255 uint8."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # window [0,80]: 0->0, 40->127(.5 rounded), 80->255, and out-of-window values clip.
+        values = np.array([[0, 40, 80, 200]], dtype=np.uint16)
+        image_path, mask_path = _write_dataset(tmp, values, np.array([[0, 1, 2, 0]], dtype=np.uint8))
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.window_preset = "brain"
+        ApplyWindowing(ctx).transform([image_path])
+
+        out = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        assert out.dtype == np.uint8
+        center, width = WINDOW_PRESETS["brain"]
+        lower = center - width / 2
+        expected = np.clip(np.array([0, 40, 80, 200], float), lower, lower + width)
+        expected = ((expected - lower) * (255.0 / width)).round().astype(np.uint8)
+        np.testing.assert_array_equal(out.reshape(-1), expected)
+        assert out.min() >= 0 and out.max() <= 255
+
+
+def test_center_width_fallback_used_when_no_preset():
+    """Without a preset, window_center/window_width from DICOM config drive the mapping."""
+    with tempfile.TemporaryDirectory() as tmp:
+        values = np.array([[0, 50, 100, 150]], dtype=np.uint16)
+        image_path, _ = _write_dataset(tmp, values, np.zeros((1, 4), dtype=np.uint8))
+
+        ctx = _make_ctx(tmp)
+        ctx.dicom.window_center = 50  # window [0, 100]
+        ctx.dicom.window_width = 100
+        ApplyWindowing(ctx).transform([image_path])
+
+        out = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        assert out.dtype == np.uint8
+        expected = np.clip(np.array([0, 50, 100, 150], float), 0, 100)
+        expected = (expected * (255.0 / 100)).round().astype(np.uint8)
+        np.testing.assert_array_equal(out.reshape(-1), expected)
+
+
+def test_no_op_when_no_window_configured():
+    """With neither preset nor center/width, the image is left byte-identical."""
+    with tempfile.TemporaryDirectory() as tmp:
+        values = np.array([[10, 20, 30, 40]], dtype=np.uint16)
+        image_path, _ = _write_dataset(tmp, values, np.zeros((1, 4), dtype=np.uint8))
+        before = open(image_path, "rb").read()
+
+        ApplyWindowing(_make_ctx(tmp)).transform([image_path])
+
+        assert open(image_path, "rb").read() == before
+
+
+def test_masks_untouched():
+    """Windowing must never modify the paired mask."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image = np.array([[0, 40, 80, 200]], dtype=np.uint16)
+        mask = np.array([[0, 1, 2, 3]], dtype=np.uint8)
+        image_path, mask_path = _write_dataset(tmp, image, mask)
+        mask_before = open(mask_path, "rb").read()
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.window_preset = "brain"
+        ApplyWindowing(ctx).transform([image_path])
+
+        assert open(mask_path, "rb").read() == mask_before

--- a/testing/tests/test_autocrop_borders.py
+++ b/testing/tests/test_autocrop_borders.py
@@ -1,0 +1,76 @@
+"""Unit tests for the AutocropBorders step using small synthetic PNGs (no external data)."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.autocrop_borders import AutocropBorders
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext rooted at ``tmp`` (synthetic dataset uid 99)."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_dataset(tmp: str, image: np.ndarray, mask: np.ndarray) -> tuple[str, str]:
+    """Write a synthetic image+mask pair into the UMIE folder layout; return their paths."""
+    image_dir = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    mask_dir = os.path.join(tmp, "99_synthetic", "CT", "Masks")
+    os.makedirs(image_dir, exist_ok=True)
+    os.makedirs(mask_dir, exist_ok=True)
+    image_path = os.path.join(image_dir, "99_0_001_x.png")
+    mask_path = os.path.join(mask_dir, "99_0_001_x.png")
+    cv2.imwrite(image_path, image)
+    cv2.imwrite(mask_path, mask)
+    return image_path, mask_path
+
+
+def test_crops_to_content_bbox_and_aligns_mask():
+    """A black-bordered content block is cropped to its bbox; the mask gets the same crop."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # 20x20 black frame with a 8x6 content block at rows 5..13, cols 4..10.
+        image = np.zeros((20, 20), dtype=np.uint8)
+        image[5:13, 4:10] = 200
+        mask = np.zeros((20, 20), dtype=np.uint8)
+        mask[6:10, 5:8] = 3
+        image_path, mask_path = _write_dataset(tmp, image, mask)
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.autocrop_enabled = True
+        AutocropBorders(ctx).transform([image_path])
+
+        out_image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        out_mask = cv2.imread(mask_path, cv2.IMREAD_UNCHANGED)
+        assert out_image.shape == (8, 6)  # cropped exactly to content bbox
+        assert out_mask.shape == (8, 6)  # mask cropped to the identical region
+        assert out_image.min() == 200  # only content remains
+        # Mask label survives at the same relative position (mask rows 6..9 -> cropped rows 1..4).
+        assert np.array_equal(np.unique(out_mask), np.array([0, 3], dtype=np.uint8))
+
+
+def test_no_op_when_disabled():
+    """With autocrop_enabled False the image is left byte-identical."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image = np.zeros((20, 20), dtype=np.uint8)
+        image[5:13, 4:10] = 200
+        image_path, _ = _write_dataset(tmp, image, np.zeros((20, 20), dtype=np.uint8))
+        before = open(image_path, "rb").read()
+
+        ctx = _make_ctx(tmp)
+        assert ctx.preprocessing.autocrop_enabled is False
+        AutocropBorders(ctx).transform([image_path])
+
+        assert open(image_path, "rb").read() == before

--- a/testing/tests/test_check_mask_quality.py
+++ b/testing/tests/test_check_mask_quality.py
@@ -1,0 +1,108 @@
+"""Unit tests for CheckMaskQuality using small synthetic PNGs (no external data)."""
+
+import json
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs, MaskColor
+from src.steps.check_mask_quality import CheckMaskQuality
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a PipelineContext whose masks allow target colours 1 and 2."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(
+            dataset_uid="99",
+            dataset_name="synthetic",
+            phases={"0": "CT"},
+            masks={
+                "Kidney": MaskColor(source_color=1, target_color=1),
+                "Neoplasm": MaskColor(source_color=2, target_color=2),
+            },
+        ),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _dirs(tmp: str) -> tuple:
+    """Create and return the synthetic Images and Masks folders."""
+    images_dir = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    masks_dir = os.path.join(tmp, "99_synthetic", "CT", "Masks")
+    os.makedirs(images_dir, exist_ok=True)
+    os.makedirs(masks_dir, exist_ok=True)
+    return images_dir, masks_dir
+
+
+def _rel(path: str, tmp: str) -> str:
+    """Return the umie_path (relative to the target/tmp dir) of an output file."""
+    return os.path.relpath(path, tmp).replace(os.sep, "/")
+
+
+def _failed_masks(report: dict, category: str) -> set:
+    """Return the set of mask paths recorded under a report category."""
+    members = set()
+    for entry in report[category]:
+        members.add(entry["mask"] if isinstance(entry, dict) else entry)
+    return members
+
+
+def test_classifies_dim_mismatch_out_of_vocab_and_valid():
+    """A dim-mismatch mask, an out-of-vocab mask and a valid mask are each classified."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir, masks_dir = _dirs(tmp)
+
+        # paired images, all 32x32
+        for name in ("valid", "vocab", "dim"):
+            cv2.imwrite(os.path.join(images_dir, f"99_0_001_{name}.png"), np.zeros((32, 32), dtype=np.uint8))
+
+        # valid mask: allowed colours only (0 and configured target colour 1)
+        valid_mask = np.zeros((32, 32), dtype=np.uint8)
+        valid_mask[5:10, 5:10] = 1
+        valid_path = os.path.join(masks_dir, "99_0_001_valid.png")
+        cv2.imwrite(valid_path, valid_mask)
+
+        # out-of-vocab mask: contains colour 200 which is not an allowed target
+        vocab_mask = np.zeros((32, 32), dtype=np.uint8)
+        vocab_mask[0, 0] = 200
+        vocab_path = os.path.join(masks_dir, "99_0_001_vocab.png")
+        cv2.imwrite(vocab_path, vocab_mask)
+
+        # dim-mismatch mask: 16x16 against a 32x32 image, otherwise valid colours
+        dim_mask = np.zeros((16, 16), dtype=np.uint8)
+        dim_mask[0, 0] = 1
+        dim_path = os.path.join(masks_dir, "99_0_001_dim.png")
+        cv2.imwrite(dim_path, dim_mask)
+
+        returned = CheckMaskQuality(_make_ctx(tmp)).transform(["unused"])
+        assert returned == ["unused"]  # X returned unchanged
+
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "mask_quality_report.json")))
+        assert _rel(dim_path, tmp) in _failed_masks(report, "dim_mismatch")
+        assert _rel(vocab_path, tmp) in _failed_masks(report, "out_of_vocab_color")
+        assert _rel(valid_path, tmp) not in _failed_masks(report, "dim_mismatch")
+        assert _rel(valid_path, tmp) not in _failed_masks(report, "out_of_vocab_color")
+        assert _rel(valid_path, tmp) not in report["empty"]
+
+
+def test_empty_mask_flagged():
+    """An all-zero mask is flagged as empty (but is not an out-of-vocab failure)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir, masks_dir = _dirs(tmp)
+        cv2.imwrite(os.path.join(images_dir, "99_0_001_empty.png"), np.zeros((32, 32), dtype=np.uint8))
+        empty_path = os.path.join(masks_dir, "99_0_001_empty.png")
+        cv2.imwrite(empty_path, np.zeros((32, 32), dtype=np.uint8))
+
+        CheckMaskQuality(_make_ctx(tmp)).transform([])
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "mask_quality_report.json")))
+        assert _rel(empty_path, tmp) in report["empty"]
+        assert _rel(empty_path, tmp) not in _failed_masks(report, "out_of_vocab_color")

--- a/testing/tests/test_convert_bbox_to_mask.py
+++ b/testing/tests/test_convert_bbox_to_mask.py
@@ -1,0 +1,126 @@
+"""Unit tests for ConvertBboxToMask across COCO / YOLO / VOC (no external data)."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.convert_bbox_to_mask import ConvertBboxToMask
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def test_render_mask_filled_box_at_correct_coords_and_color():
+    """A single mapped box renders a filled rectangle of the mapped colour at its coords."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        ctx.format_conversion.bbox_class_map = {7: 5}
+        ctx.format_conversion.bbox_as_filled = True
+        step = ConvertBboxToMask(ctx)
+
+        mask = step._render_mask([(7, 2, 3, 6, 8)], height=20, width=20)
+        assert mask[3, 2] == 5  # top-left corner inside the box
+        assert mask[8, 6] == 5  # bottom-right corner inside the box
+        assert mask[5, 4] == 5  # interior is filled
+        assert mask[0, 0] == 0  # outside the box stays background
+
+
+def test_coco_multi_box_accumulation():
+    """Multiple COCO boxes for one image accumulate into a single mask."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        ctx.format_conversion.bbox_class_map = {1: 5, 2: 7}
+        step = ConvertBboxToMask(ctx)
+
+        coco = {
+            "images": [{"id": 10, "file_name": "scan.png", "height": 30, "width": 30}],
+            "annotations": [
+                {"image_id": 10, "category_id": 1, "bbox": [2, 2, 5, 5]},
+                {"image_id": 10, "category_id": 2, "bbox": [20, 20, 5, 5]},
+            ],
+        }
+        parsed = step._boxes_from_coco(coco)
+        height, width, boxes = parsed[10]
+        assert (height, width) == (30, 30)
+        mask = step._render_mask(boxes, height, width)
+        assert mask[4, 4] == 5  # first box colour
+        assert mask[22, 22] == 7  # second box colour
+        assert mask[15, 15] == 0  # gap between boxes
+
+
+def test_yolo_normalized_box_maps_to_pixels():
+    """A YOLO normalized box maps to the expected absolute pixel rectangle and colour."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        ctx.format_conversion.bbox_class_map = {0: 5}
+        step = ConvertBboxToMask(ctx)
+
+        # class 0, centre (0.5, 0.5), size 0.5x0.5 on a 100x100 image -> [25,25]..[75,75].
+        boxes = step._boxes_from_yolo(["0 0.5 0.5 0.5 0.5"], height=100, width=100)
+        assert boxes == [(0, 25, 25, 75, 75)]
+        mask = step._render_mask(boxes, 100, 100)
+        assert mask[50, 50] == 5
+        assert mask[10, 10] == 0
+
+
+def test_voc_xml_box_parsed_and_rendered():
+    """A Pascal VOC XML object yields the right size, box and rendered colour."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        ctx.format_conversion.bbox_class_map = {"lesion": 11}
+        step = ConvertBboxToMask(ctx)
+
+        xml_text = (
+            "<annotation><filename>scan.png</filename>"
+            "<size><height>40</height><width>40</width></size>"
+            "<object><name>lesion</name>"
+            "<bndbox><xmin>5</xmin><ymin>6</ymin><xmax>15</xmax><ymax>16</ymax></bndbox>"
+            "</object></annotation>"
+        )
+        height, width, boxes = step._boxes_from_voc(xml_text)
+        assert (height, width) == (40, 40)
+        assert boxes == [("lesion", 5, 6, 15, 16)]
+        mask = step._render_mask(boxes, height, width)
+        assert mask[10, 10] == 11
+        assert mask[0, 0] == 0
+
+
+def test_transform_coco_writes_mask_png():
+    """End-to-end COCO transform writes an accumulated mask PNG under the Masks folder."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        ctx.format_conversion.bbox_format = "coco"
+        ctx.format_conversion.bbox_class_map = {1: 5}
+
+        coco = {
+            "images": [{"id": 1, "file_name": "scan.png", "height": 20, "width": 20}],
+            "annotations": [{"image_id": 1, "category_id": 1, "bbox": [4, 4, 6, 6]}],
+        }
+        import json as _json
+
+        with open(os.path.join(tmp, "annotations.json"), "w") as handle:
+            _json.dump(coco, handle)
+
+        returned = ConvertBboxToMask(ctx).transform(["unused"])
+        assert returned == ["unused"]
+
+        mask_path = os.path.join(tmp, "99_synthetic", "CT", "Masks", "scan.png")
+        mask = cv2.imread(mask_path, cv2.IMREAD_GRAYSCALE)
+        assert mask is not None
+        assert mask[6, 6] == 5
+        assert int(np.count_nonzero(mask)) > 0

--- a/testing/tests/test_convert_dicom_seg.py
+++ b/testing/tests/test_convert_dicom_seg.py
@@ -1,0 +1,139 @@
+"""Unit tests for ConvertDicomSeg helpers using tiny synthetic Datasets (no external data)."""
+
+import tempfile
+
+import numpy as np
+from pydicom.dataset import Dataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.convert_dicom_seg import ConvertDicomSeg
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def test_patient_to_pixel_identity_orientation_unit_spacing():
+    """Identity orientation and unit spacing map patient (x, y) directly to (col, row)."""
+    image_position = [0.0, 0.0, 0.0]
+    image_orientation = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]  # axis-aligned
+    pixel_spacing = [1.0, 1.0]
+
+    assert ConvertDicomSeg._patient_to_pixel((3.0, 4.0, 0.0), image_position, image_orientation, pixel_spacing) == (
+        4,
+        3,
+    )
+    assert ConvertDicomSeg._patient_to_pixel((0.0, 0.0, 0.0), image_position, image_orientation, pixel_spacing) == (
+        0,
+        0,
+    )
+
+
+def test_rasterize_contour_axis_aligned_square():
+    """An axis-aligned square contour fills the expected pixel bbox with the given colour."""
+    image_position = [0.0, 0.0, 0.0]
+    image_orientation = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+    pixel_spacing = [1.0, 1.0]
+    # square with corners (2,2)..(6,6) in patient coords (x, y, z)
+    square = [(2.0, 2.0, 0.0), (6.0, 2.0, 0.0), (6.0, 6.0, 0.0), (2.0, 6.0, 0.0)]
+
+    mask = ConvertDicomSeg._rasterize_contour(
+        square, image_position, image_orientation, pixel_spacing, rows=10, cols=10, color=5
+    )
+    assert mask[4, 4] == 5  # interior filled
+    assert mask[2, 2] == 5  # corner of the square
+    assert mask[0, 0] == 0  # outside the square
+    assert mask[8, 8] == 0
+    # filled region spans the expected pixel bbox
+    rows, cols = np.where(mask == 5)
+    assert rows.min() == 2 and cols.min() == 2
+    assert rows.max() == 6 and cols.max() == 6
+
+
+def _segment(number: int, label: str) -> Dataset:
+    """Build a minimal SegmentSequence item."""
+    item = Dataset()
+    item.SegmentNumber = number
+    item.SegmentLabel = label
+    return item
+
+
+def _frame_group(segment_number: int) -> Dataset:
+    """Build a minimal PerFrameFunctionalGroups item referencing a segment number."""
+    seg_id = Dataset()
+    seg_id.ReferencedSegmentNumber = segment_number
+    group = Dataset()
+    group.SegmentIdentificationSequence = [seg_id]
+    return group
+
+
+def _seg_dataset(frames: np.ndarray) -> Dataset:
+    """Build a minimal multi-frame SEG Dataset whose pixel_array decodes (file_meta set)."""
+    meta = FileMetaDataset()
+    meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds = Dataset()
+    ds.file_meta = meta
+    ds.PixelData = frames.tobytes()
+    ds.Rows = int(frames.shape[1])
+    ds.Columns = int(frames.shape[2])
+    ds.NumberOfFrames = int(frames.shape[0])
+    ds.BitsAllocated = 8
+    ds.BitsStored = 8
+    ds.HighBit = 7
+    ds.SamplesPerPixel = 1
+    ds.PixelRepresentation = 0
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    return ds
+
+
+def test_seg_to_masks_two_frame_binary():
+    """A 2-frame binary SEG yields a mask per frame with each segment's colour where pixels==1."""
+    with tempfile.TemporaryDirectory() as tmp:
+        step = ConvertDicomSeg(_make_ctx(tmp))
+
+        # two binary frames, one per segment
+        frame0 = np.zeros((4, 4), dtype=np.uint8)
+        frame0[0:2, 0:2] = 1
+        frame1 = np.zeros((4, 4), dtype=np.uint8)
+        frame1[2:4, 2:4] = 1
+        ds = _seg_dataset(np.stack([frame0, frame1]))
+        # two segments mapped to config/masks RadLex names -> colours Kidney=1, Neoplasm=2
+        ds.SegmentSequence = [_segment(1, "Kidney"), _segment(2, "Neoplasm")]
+        ds.PerFrameFunctionalGroupsSequence = [_frame_group(1), _frame_group(2)]
+
+        masks = step._seg_to_masks(ds)
+        # no DerivationImageSequence -> frames keyed by index
+        assert set(masks.keys()) == {0, 1}
+        assert masks[0][0, 0] == 1  # segment 1 -> Kidney colour
+        assert masks[0][3, 3] == 0
+        assert masks[1][3, 3] == 2  # segment 2 -> Neoplasm colour
+        assert masks[1][0, 0] == 0
+
+
+def test_seg_to_masks_uses_structure_map_override():
+    """A configured segmentation_structure_map overrides the config/masks fallback colour."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        ctx.format_conversion.segmentation_structure_map = {"MyTumor": 13}
+        step = ConvertDicomSeg(ctx)
+
+        frame0 = np.zeros((4, 4), dtype=np.uint8)
+        frame0[0:2, 0:2] = 1
+        ds = _seg_dataset(frame0[np.newaxis, ...])
+        ds.SegmentSequence = [_segment(1, "MyTumor")]
+        ds.PerFrameFunctionalGroupsSequence = [_frame_group(1)]
+
+        masks = step._seg_to_masks(ds)
+        assert masks[0][0, 0] == 13  # mapped via structure map override

--- a/testing/tests/test_create_manifest.py
+++ b/testing/tests/test_create_manifest.py
@@ -1,0 +1,102 @@
+"""Unit tests for CreateManifest: hashing, reports/ exclusion, and verify-mode categories."""
+
+import hashlib
+import json
+import os
+import tempfile
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.create_manifest import CreateManifest
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write(path: str, data: bytes) -> None:
+    """Create parent dirs and write ``data`` to ``path``."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as handle:
+        handle.write(data)
+
+
+def _sha256(data: bytes) -> str:
+    """Return the SHA-256 hex digest of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_manifest_hashes_match_and_reports_excluded():
+    """Manifest digests equal a hashlib recompute; reports/ and the manifest are excluded."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        step = CreateManifest(ctx)
+        root = step.dataset_root
+
+        img = os.path.join(root, "CT", "Images", "99_0_001_a.png")
+        jsonl = os.path.join(root, "99_synthetic.jsonl")
+        _write(img, b"image-bytes")
+        _write(jsonl, b'{"umie_id": "99_0_001_a.png"}\n')
+
+        # A pre-existing report file must NOT appear in the manifest.
+        _write(os.path.join(step.reports_dir(), "some_report.json"), b"{}")
+
+        returned = step.transform(["unchanged"])
+        assert returned == ["unchanged"]  # X passes through untouched
+
+        manifest_path = os.path.join(step.reports_dir(), "manifest.json")
+        manifest = json.load(open(manifest_path))
+
+        assert manifest["CT/Images/99_0_001_a.png"] == _sha256(b"image-bytes")
+        assert manifest["99_synthetic.jsonl"] == _sha256(b'{"umie_id": "99_0_001_a.png"}\n')
+
+        # Nothing under reports/ (incl. the manifest itself) is in the manifest.
+        assert not any(rel.startswith("reports/") for rel in manifest)
+        assert "reports/manifest.json" not in manifest
+        assert "reports/some_report.json" not in manifest
+
+
+def test_verify_reports_missing_changed_and_extra():
+    """Verify mode flags a changed, a missing, and an extra file correctly."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        step = CreateManifest(ctx)
+        root = step.dataset_root
+
+        keep = os.path.join(root, "CT", "Images", "keep.png")
+        to_change = os.path.join(root, "CT", "Images", "change.png")
+        to_delete = os.path.join(root, "CT", "Images", "delete.png")
+        _write(keep, b"keep")
+        _write(to_change, b"original")
+        _write(to_delete, b"delete-me")
+
+        # Build the baseline manifest.
+        step.transform([])
+
+        # Mutate the outputs: change one, delete one, add one.
+        _write(to_change, b"MODIFIED")
+        os.remove(to_delete)
+        added = os.path.join(root, "CT", "Images", "extra.png")
+        _write(added, b"new-file")
+
+        # Switch to verify mode (manifest must not be rewritten).
+        manifest_path = os.path.join(step.reports_dir(), "manifest.json")
+        before = open(manifest_path).read()
+        ctx.export.verify_manifest = True
+        CreateManifest(ctx).transform([])
+        assert open(manifest_path).read() == before  # manifest untouched in verify mode
+
+        report = json.load(open(os.path.join(step.reports_dir(), "manifest_verification.json")))
+        assert report["changed"] == ["CT/Images/change.png"]
+        assert report["missing"] == ["CT/Images/delete.png"]
+        assert report["extra"] == ["CT/Images/extra.png"]

--- a/testing/tests/test_create_splits.py
+++ b/testing/tests/test_create_splits.py
@@ -1,0 +1,125 @@
+"""Unit tests for CreateSplits: study-level, reproducible, roughly-ratio'd stratified splits."""
+
+import os
+import tempfile
+
+import jsonlines
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.create_splits import CreateSplits
+
+
+def _make_ctx(tmp: str, dataset_name: str = "synthetic") -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name=dataset_name, phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_jsonl(tmp: str, num_studies: int = 40, slices_per_study: int = 3) -> str:
+    """Write a JSONL with many study ids, several image records each, some labelled."""
+    dataset_dir = os.path.join(tmp, "99_synthetic")
+    os.makedirs(dataset_dir, exist_ok=True)
+    jsonl_path = os.path.join(dataset_dir, "99_synthetic.jsonl")
+
+    with jsonlines.open(jsonl_path, mode="w") as writer:
+        for study in range(num_studies):
+            # Alternate labels across studies so stratification has something to balance.
+            labels = [{"Neoplasm": 1}] if study % 2 == 0 else [{"NormalityDecriptor": 1}]
+            for slice_idx in range(slices_per_study):
+                writer.write(
+                    {
+                        "umie_path": f"99_synthetic/CT/Images/99_0_{study}_{slice_idx}.png",
+                        "dataset_name": "synthetic",
+                        "dataset_uid": "99",
+                        "phase_name": "CT",
+                        "comparative": "",
+                        "study_id": str(study),
+                        "umie_id": f"99_0_{study}_{slice_idx}.png",
+                        "mask_path": "",
+                        "labels": labels,
+                        "source_labels": [],
+                    }
+                )
+    return jsonl_path
+
+
+def _read_records(jsonl_path: str) -> list:
+    """Read all JSONL records from a path."""
+    with jsonlines.open(jsonl_path, mode="r") as reader:
+        return list(reader)
+
+
+def _study_to_split(records: list) -> dict:
+    """Build a {study_id: set_of_splits} map to detect leakage."""
+    mapping: dict = {}
+    for record in records:
+        mapping.setdefault(record["study_id"], set()).add(record["split"])
+    return mapping
+
+
+def test_no_study_leaks_across_splits():
+    """Every study_id must appear in exactly one split (critical for 3D volumes)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp)
+        CreateSplits(_make_ctx(tmp)).transform([])
+
+        mapping = _study_to_split(_read_records(jsonl_path))
+        for study_id, splits in mapping.items():
+            assert len(splits) == 1, f"study {study_id} leaked across splits {splits}"
+
+
+def test_deterministic_with_same_seed():
+    """Running twice with the same seed yields identical study->split assignment."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp)
+
+        CreateSplits(_make_ctx(tmp)).transform([])
+        first = {r["study_id"]: r["split"] for r in _read_records(jsonl_path)}
+
+        CreateSplits(_make_ctx(tmp)).transform([])
+        second = {r["study_id"]: r["split"] for r in _read_records(jsonl_path)}
+
+        assert first == second
+
+
+def test_split_sizes_roughly_match_ratios():
+    """Study-level split sizes should roughly follow split_ratios (0.7/0.15/0.15)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp, num_studies=40)
+        CreateSplits(_make_ctx(tmp)).transform([])
+
+        mapping = _study_to_split(_read_records(jsonl_path))
+        split_of_study = {study: next(iter(splits)) for study, splits in mapping.items()}
+        total = len(split_of_study)
+        counts = {
+            "train": sum(1 for s in split_of_study.values() if s == "train"),
+            "val": sum(1 for s in split_of_study.values() if s == "val"),
+            "test": sum(1 for s in split_of_study.values() if s == "test"),
+        }
+        assert sum(counts.values()) == total
+        # Allow a generous tolerance for rounding within strata.
+        assert abs(counts["train"] / total - 0.7) < 0.15
+        assert abs(counts["val"] / total - 0.15) < 0.15
+        assert abs(counts["test"] / total - 0.15) < 0.15
+
+
+def test_manifest_only_leaves_jsonl_untouched():
+    """With split_manifest_only, no `split` field is added and a manifest is written."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path = _write_jsonl(tmp, num_studies=10)
+        ctx = _make_ctx(tmp)
+        ctx.metadata.split_manifest_only = True
+        CreateSplits(ctx).transform([])
+
+        assert all("split" not in r for r in _read_records(jsonl_path))
+        manifest = os.path.join(tmp, "99_synthetic", "reports", "split_manifest.json")
+        assert os.path.exists(manifest)

--- a/testing/tests/test_detect_corrupt_images.py
+++ b/testing/tests/test_detect_corrupt_images.py
@@ -1,0 +1,103 @@
+"""Unit tests for DetectCorruptImages using small synthetic PNGs (no external data)."""
+
+import json
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.detect_corrupt_images import DetectCorruptImages
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _images_dir(tmp: str) -> str:
+    """Create and return the synthetic Images folder."""
+    path = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _rel(path: str, tmp: str) -> str:
+    """Return the umie_path (relative to the target/tmp dir) of an output file."""
+    return os.path.relpath(path, tmp).replace(os.sep, "/")
+
+
+def test_valid_blank_and_unreadable_classification():
+    """A valid image passes, a garbage file is unreadable, an all-black frame is blank."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+
+        valid_path = os.path.join(images_dir, "99_0_001_valid.png")
+        rng = np.random.default_rng(0)
+        cv2.imwrite(valid_path, rng.integers(0, 256, size=(32, 32), dtype=np.uint8))
+
+        blank_path = os.path.join(images_dir, "99_0_002_blank.png")
+        cv2.imwrite(blank_path, np.zeros((32, 32), dtype=np.uint8))
+
+        garbage_path = os.path.join(images_dir, "99_0_003_garbage.png")
+        with open(garbage_path, "wb") as handle:
+            handle.write(b"not a real png file")
+
+        returned = DetectCorruptImages(_make_ctx(tmp)).transform([valid_path])
+        assert returned == [valid_path]  # X returned unchanged
+
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "corrupt_images_report.json")))
+        assert _rel(valid_path, tmp) not in report["quarantine"]
+        assert _rel(blank_path, tmp) in report["blank"]
+        assert _rel(garbage_path, tmp) in report["unreadable"]
+        assert _rel(blank_path, tmp) in report["quarantine"]
+        assert _rel(garbage_path, tmp) in report["quarantine"]
+
+
+def test_blank_threshold_configurable():
+    """A low-variance image is blank only when blank_std_threshold is raised above its std."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        low_var = np.zeros((32, 32), dtype=np.uint8)
+        low_var[0, 0] = 5  # tiny variation -> small but non-zero std
+        path = os.path.join(images_dir, "99_0_001_lowvar.png")
+        cv2.imwrite(path, low_var)
+
+        # default threshold (1.0) -> std is below it, flagged blank
+        DetectCorruptImages(_make_ctx(tmp)).transform([path])
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "corrupt_images_report.json")))
+        assert _rel(path, tmp) in report["blank"]
+
+        # threshold lowered to 0 -> nothing is blank
+        ctx = _make_ctx(tmp)
+        ctx.quality.blank_std_threshold = 0.0
+        DetectCorruptImages(ctx).transform([path])
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "corrupt_images_report.json")))
+        assert _rel(path, tmp) not in report["blank"]
+
+
+def test_too_small_reported():
+    """An image smaller than expected_min_size is reported as too_small."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        rng = np.random.default_rng(1)
+        small = os.path.join(images_dir, "99_0_001_small.png")
+        cv2.imwrite(small, rng.integers(0, 256, size=(16, 16), dtype=np.uint8))
+
+        ctx = _make_ctx(tmp)
+        ctx.quality.expected_min_size = (32, 32)
+        DetectCorruptImages(ctx).transform([small])
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "corrupt_images_report.json")))
+        assert _rel(small, tmp) in report["too_small"]
+        assert _rel(small, tmp) in report["quarantine"]

--- a/testing/tests/test_detect_duplicates.py
+++ b/testing/tests/test_detect_duplicates.py
@@ -1,0 +1,176 @@
+"""Unit tests for DetectDuplicates using small synthetic PNGs (no external data)."""
+
+import json
+import os
+import tempfile
+
+import cv2
+import jsonlines
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.detect_duplicates import DetectDuplicates
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _images_dir(tmp: str) -> str:
+    """Create and return the synthetic Images folder."""
+    path = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _gradient(seed: int) -> np.ndarray:
+    """Build a deterministic 64x64 grayscale gradient image distinct per seed."""
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, 256, size=(64, 64), dtype=np.uint8)
+
+
+def _write_synthetic(images_dir: str) -> dict:
+    """Write an exact-duplicate pair, a near-duplicate pair and a distinct image."""
+    base = _gradient(1)
+    near = base.copy()
+    # invert a small corner block -> a near duplicate at dHash distance 3 (within the
+    # default threshold of 5, but excluded at threshold 0).
+    near[:16, :16] = 255 - near[:16, :16]
+    distinct = _gradient(99)
+
+    paths = {
+        "exact_a": os.path.join(images_dir, "99_0_001_a.png"),
+        "exact_b": os.path.join(images_dir, "99_0_002_b.png"),
+        "near": os.path.join(images_dir, "99_0_003_c.png"),
+        "distinct": os.path.join(images_dir, "99_0_004_d.png"),
+    }
+    cv2.imwrite(paths["exact_a"], base)
+    cv2.imwrite(paths["exact_b"], base)
+    cv2.imwrite(paths["near"], near)
+    cv2.imwrite(paths["distinct"], distinct)
+    return paths
+
+
+def _rel(path: str, tmp: str) -> str:
+    """Return the umie_path (relative to the target/tmp dir) of an output file."""
+    return os.path.relpath(path, tmp).replace(os.sep, "/")
+
+
+def test_duplicates_cluster_and_distinct_does_not():
+    """Exact and near duplicates cluster together; the distinct image stays out."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        paths = _write_synthetic(images_dir)
+        ctx = _make_ctx(tmp)
+
+        returned = DetectDuplicates(ctx).transform(list(paths.values()))
+        assert returned == list(paths.values())  # X returned unchanged
+
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "duplicates_report.json")))
+        clusters = report["clusters"]
+        assert len(clusters) == 1
+        members = set(clusters[0]["members"])
+        assert _rel(paths["exact_a"], tmp) in members
+        assert _rel(paths["exact_b"], tmp) in members
+        assert _rel(paths["near"], tmp) in members
+        assert _rel(paths["distinct"], tmp) not in members
+
+
+def test_nothing_deleted_and_csv_written():
+    """Detection never deletes any image and writes both JSON and CSV reports."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        paths = _write_synthetic(images_dir)
+        DetectDuplicates(_make_ctx(tmp)).transform(list(paths.values()))
+
+        for path in paths.values():
+            assert os.path.exists(path)
+        reports_dir = os.path.join(tmp, "99_synthetic", "reports")
+        assert os.path.exists(os.path.join(reports_dir, "duplicates_report.json"))
+        assert os.path.exists(os.path.join(reports_dir, "duplicates_report.csv"))
+
+
+def test_threshold_is_honored():
+    """A threshold of 0 only clusters exact duplicates, not the near-duplicate."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        paths = _write_synthetic(images_dir)
+        ctx = _make_ctx(tmp)
+        ctx.quality.duplicate_threshold = 0
+
+        DetectDuplicates(ctx).transform(list(paths.values()))
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "duplicates_report.json")))
+        clusters = report["clusters"]
+        assert len(clusters) == 1
+        members = set(clusters[0]["members"])
+        # exact pair clusters, near-duplicate does not at distance 0
+        assert _rel(paths["exact_a"], tmp) in members
+        assert _rel(paths["exact_b"], tmp) in members
+        assert _rel(paths["near"], tmp) not in members
+        assert clusters[0]["max_distance"] == 0
+
+
+def _seed_jsonl(tmp: str, paths: dict) -> str:
+    """Write a synthetic JSONL with one record per image and return its path."""
+    json_path = os.path.join(tmp, "99_synthetic", "99_synthetic.jsonl")
+    records = [{"umie_path": _rel(path, tmp), "labels": []} for path in paths.values()]
+    with jsonlines.open(json_path, mode="w") as writer:
+        for record in records:
+            writer.write(record)
+    return json_path
+
+
+def test_flag_adds_group_id_only_when_enabled():
+    """duplicate_group_id is added to clustered records only when flagging is enabled."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        paths = _write_synthetic(images_dir)
+        json_path = _seed_jsonl(tmp, paths)
+
+        # disabled (default): no group id written anywhere
+        DetectDuplicates(_make_ctx(tmp)).transform(list(paths.values()))
+        with jsonlines.open(json_path, mode="r") as reader:
+            assert all("duplicate_group_id" not in obj for obj in reader)
+
+        # enabled: clustered records get a group id, the distinct record does not
+        ctx = _make_ctx(tmp)
+        ctx.quality.flag_duplicates_in_jsonl = True
+        DetectDuplicates(ctx).transform(list(paths.values()))
+        with jsonlines.open(json_path, mode="r") as reader:
+            by_path = {obj["umie_path"]: obj for obj in reader}
+        assert "duplicate_group_id" in by_path[_rel(paths["exact_a"], tmp)]
+        assert "duplicate_group_id" in by_path[_rel(paths["near"], tmp)]
+        assert "duplicate_group_id" not in by_path[_rel(paths["distinct"], tmp)]
+        # all original fields preserved
+        assert by_path[_rel(paths["distinct"], tmp)]["labels"] == []
+
+
+def test_cross_dataset_reference_hashes():
+    """An external reference-hash JSON lets cross-dataset overlaps surface in a cluster."""
+    with tempfile.TemporaryDirectory() as tmp:
+        images_dir = _images_dir(tmp)
+        paths = _write_synthetic(images_dir)
+        ctx = _make_ctx(tmp)
+
+        step = DetectDuplicates(ctx)
+        base_image = cv2.imread(paths["exact_a"], cv2.IMREAD_GRAYSCALE)
+        reference = {"other/00_0_001_x.png": step._dhash(base_image)}
+        ref_path = os.path.join(tmp, "reference.json")
+        json.dump(reference, open(ref_path, "w"))
+        ctx.quality.duplicate_reference_hashes = ref_path
+
+        DetectDuplicates(ctx).transform(list(paths.values()))
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "duplicates_report.json")))
+        all_members = {member for cluster in report["clusters"] for member in cluster["members"]}
+        assert "other/00_0_001_x.png" in all_members

--- a/testing/tests/test_distribution_report.py
+++ b/testing/tests/test_distribution_report.py
@@ -1,0 +1,93 @@
+"""Unit tests for the distribution_report utility (Task 22)."""
+
+import os
+import tempfile
+
+import jsonlines
+
+from utils.distribution_report import generate_distribution_report
+
+
+def _write_dataset(data_dir: str, uid: str, name: str, records: list) -> None:
+    """Write one dataset JSONL at {data_dir}/{uid}_{name}/{uid}_{name}.jsonl."""
+    dataset_dir = os.path.join(data_dir, f"{uid}_{name}")
+    os.makedirs(dataset_dir, exist_ok=True)
+    jsonl_path = os.path.join(dataset_dir, f"{uid}_{name}.jsonl")
+    with jsonlines.open(jsonl_path, mode="w") as writer:
+        for record in records:
+            writer.write(record)
+
+
+def _record(study_id: str, phase_name: str, labels: list) -> dict:
+    """Build a minimal JSONL record."""
+    return {
+        "umie_path": f"x/{study_id}.png",
+        "dataset_name": "ds",
+        "dataset_uid": "00",
+        "phase_name": phase_name,
+        "comparative": "",
+        "study_id": study_id,
+        "umie_id": f"{study_id}.png",
+        "mask_path": "",
+        "labels": labels,
+        "source_labels": [],
+    }
+
+
+def test_label_and_modality_counts():
+    """The returned dict has the expected per-dataset and global label / modality counts."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_dataset(
+            tmp,
+            "00",
+            "alpha",
+            [
+                _record("1", "CT", [{"Neoplasm": 1}]),
+                _record("2", "CT", [{"Neoplasm": 1}, {"NormalityDecriptor": 1}]),
+                _record("3", "MRI", []),
+            ],
+        )
+        _write_dataset(
+            tmp,
+            "01",
+            "beta",
+            [
+                _record("1", "XRay", [{"NormalityDecriptor": 1}]),
+            ],
+        )
+
+        stats = generate_distribution_report(tmp)
+
+        assert stats["num_datasets"] == 2
+        assert stats["total_records"] == 4
+
+        alpha = stats["per_dataset"]["00_alpha"]
+        assert alpha["label_counts"] == {"Neoplasm": 2, "NormalityDecriptor": 1}
+        assert alpha["modality_counts"] == {"CT": 2, "MRI": 1}
+        # class imbalance = max(2)/min(1) = 2.0
+        assert alpha["class_imbalance_ratio"] == 2.0
+
+        beta = stats["per_dataset"]["01_beta"]
+        assert beta["label_counts"] == {"NormalityDecriptor": 1}
+        assert beta["modality_counts"] == {"XRay": 1}
+        # single label -> no imbalance ratio
+        assert beta["class_imbalance_ratio"] is None
+
+        glob_labels = stats["global"]["label_counts"]
+        assert glob_labels == {"Neoplasm": 2, "NormalityDecriptor": 2}
+        assert stats["global"]["modality_counts"] == {"CT": 2, "MRI": 1, "XRay": 1}
+
+
+def test_reports_written_and_empty_dir_is_safe():
+    """Markdown + CSV reports are written by default; an empty dir produces empty stats."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_dataset(tmp, "00", "alpha", [_record("1", "CT", [{"Neoplasm": 1}])])
+        generate_distribution_report(tmp)
+        assert os.path.exists(os.path.join(tmp, "distribution_report.md"))
+        assert os.path.exists(os.path.join(tmp, "distribution_report.csv"))
+
+    with tempfile.TemporaryDirectory() as empty:
+        stats = generate_distribution_report(empty)
+        assert stats["num_datasets"] == 0
+        assert stats["total_records"] == 0
+        assert stats["global"]["label_counts"] == {}

--- a/testing/tests/test_export_huggingface.py
+++ b/testing/tests/test_export_huggingface.py
@@ -1,0 +1,139 @@
+"""Unit tests for ExportHuggingFace: on-disk HuggingFace ``datasets`` export + dataset card."""
+
+import json
+import os
+import tempfile
+
+import jsonlines
+import numpy as np
+from PIL import Image as PILImage
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from config.provenance import get_provenance
+from datasets import DatasetDict, load_from_disk  # type: ignore[attr-defined]
+from src.steps.export_huggingface import ExportHuggingFace
+
+DATASET_NAME = "kits23"
+DATASET_UID = "99"
+DATASET_DIR = f"{DATASET_UID}_{DATASET_NAME}"
+
+
+def _make_ctx(tmp: str, dataset_name: str = DATASET_NAME) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid=DATASET_UID, dataset_name=dataset_name, phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_png(path: str) -> None:
+    """Write a small real RGB PNG at ``path`` (creating parent directories)."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    array = np.random.randint(0, 255, size=(8, 8, 3), dtype=np.uint8)
+    PILImage.fromarray(array).save(path)
+
+
+def _build_tiny_dataset(tmp: str) -> list:
+    """Create a tiny dataset dir with PNGs + a split-aware JSONL; return the written records."""
+    records = []
+    splits = ["train", "train", "val", "test"]
+    for index, split in enumerate(splits):
+        umie_id = f"99_0_{index:03d}_x.png"
+        umie_path = f"{DATASET_DIR}/CT/Images/{umie_id}"
+        mask_path = f"{DATASET_DIR}/CT/Masks/{umie_id}"
+        _write_png(os.path.join(tmp, umie_path))
+        _write_png(os.path.join(tmp, mask_path))
+        records.append(
+            {
+                "umie_path": umie_path,
+                "dataset_name": DATASET_NAME,
+                "dataset_uid": DATASET_UID,
+                "phase_name": "CT",
+                "comparative": "",
+                "study_id": str(index),
+                "umie_id": umie_id,
+                "mask_path": mask_path,
+                "labels": [{"normal": 1}, {"neoplasm": 1}],
+                "source_labels": ["normal"],
+                "split": split,
+            }
+        )
+
+    jsonl_path = os.path.join(tmp, DATASET_DIR, f"{DATASET_DIR}.jsonl")
+    with jsonlines.open(jsonl_path, mode="w") as writer:
+        for record in records:
+            writer.write(record)
+    return records
+
+
+def test_export_roundtrips_with_splits_and_card():
+    """Run the step, then load_from_disk and assert splits, counts, labels and the card."""
+    with tempfile.TemporaryDirectory() as tmp:
+        records = _build_tiny_dataset(tmp)
+        ctx = _make_ctx(tmp)
+        export_dir = os.path.join(tmp, "hf_export")
+        ctx.export.hf_export_path = export_dir
+
+        result = ExportHuggingFace(ctx).transform(["unchanged"])
+        # (transform returns X unchanged)
+        assert result == ["unchanged"]
+
+        loaded = load_from_disk(export_dir)
+
+        # (a) DatasetDict with the expected splits.
+        assert isinstance(loaded, DatasetDict)
+        assert set(loaded.keys()) == {"train", "val", "test"}
+        assert loaded["train"].num_rows == 2
+        assert loaded["val"].num_rows == 1
+        assert loaded["test"].num_rows == 1
+
+        # (b) Total record count matches the JSONL.
+        total = sum(split.num_rows for split in loaded.values())
+        assert total == len(records)
+
+        # (c) The labels column round-trips (flattened JSON string -> {name: grade}).
+        labels = json.loads(loaded["train"][0]["labels"])
+        assert labels == {"normal": 1, "neoplasm": 1}
+
+        # Image column round-trips to a real PIL image.
+        assert loaded["train"][0]["image"].size == (8, 8)
+        # Scalar fields are preserved.
+        assert loaded["train"][0]["dataset_uid"] == DATASET_UID
+
+        # (d) README.md card exists and contains the provenance license string.
+        card_path = os.path.join(export_dir, "README.md")
+        assert os.path.exists(card_path)
+        with open(card_path, encoding="utf-8") as card:
+            card_text = card.read()
+        assert get_provenance(DATASET_NAME).license in card_text
+        assert "CT" in card_text
+
+
+def test_export_defaults_path_and_single_split():
+    """Without a split field the export is a single-split DatasetDict at the default path."""
+    with tempfile.TemporaryDirectory() as tmp:
+        records = _build_tiny_dataset(tmp)
+        # Strip the split field and rewrite the JSONL.
+        jsonl_path = os.path.join(tmp, DATASET_DIR, f"{DATASET_DIR}.jsonl")
+        for record in records:
+            record.pop("split", None)
+        with jsonlines.open(jsonl_path, mode="w") as writer:
+            for record in records:
+                writer.write(record)
+
+        ctx = _make_ctx(tmp)
+        ExportHuggingFace(ctx).transform([])
+
+        # Default export path is f"{dataset_root}/huggingface".
+        export_dir = os.path.join(tmp, DATASET_DIR, "huggingface")
+        loaded = load_from_disk(export_dir)
+        assert isinstance(loaded, DatasetDict)
+        assert set(loaded.keys()) == {"train"}
+        assert loaded["train"].num_rows == len(records)

--- a/testing/tests/test_extract_dicom_metadata.py
+++ b/testing/tests/test_extract_dicom_metadata.py
@@ -1,0 +1,153 @@
+"""Unit tests for ExtractDicomMetadata using tiny synthetic DICOMs (no external data)."""
+
+import json
+import os
+import tempfile
+
+import jsonlines
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import CTImageStorage, ExplicitVRLittleEndian, generate_uid
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.extract_dicom_metadata import ExtractDicomMetadata
+
+
+def _make_ctx(tmp: str, dataset_name: str = "synthetic") -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name=dataset_name, phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_dicom(path: str) -> None:
+    """Write a tiny DICOM with a mix of technical tags and a PHI tag (PatientName)."""
+    meta = FileMetaDataset()
+    meta.MediaStorageSOPClassUID = CTImageStorage
+    meta.MediaStorageSOPInstanceUID = generate_uid()
+    meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds = FileDataset(path, {}, file_meta=meta, preamble=b"\0" * 128)
+    ds.SOPClassUID = CTImageStorage
+    ds.SOPInstanceUID = meta.MediaStorageSOPInstanceUID
+    ds.Modality = "CT"
+    ds.PatientSex = "F"
+    ds.SliceThickness = "1.5"
+    ds.KVP = "120"
+    ds.StudyDate = "20200115"
+    ds.PatientName = "DOE^JANE"  # PHI - must never be written when de-identifying
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+    ds.save_as(path)
+
+
+def _setup_dataset(tmp: str) -> tuple[str, str]:
+    """Create a JSONL record, a matching umie image file, a DICOM, and source_paths.json.
+
+    Returns:
+        tuple[str, str]: (jsonl_path, umie_abs_image_path).
+    """
+    dataset_dir = os.path.join(tmp, "99_synthetic")
+    images_dir = os.path.join(dataset_dir, "CT", "Images")
+    os.makedirs(images_dir, exist_ok=True)
+
+    umie_id = "99_0_1_0.png"
+    umie_abs = os.path.join(images_dir, umie_id)
+    with open(umie_abs, "wb") as handle:
+        handle.write(b"fake-png")
+    umie_path = os.path.relpath(umie_abs, tmp)
+
+    dcm_path = os.path.join(tmp, "source_0.dcm")
+    _write_dicom(dcm_path)
+
+    with open(os.path.join(tmp, "source_paths.json"), "w") as handle:
+        json.dump({umie_abs: dcm_path}, handle)
+
+    jsonl_path = os.path.join(dataset_dir, "99_synthetic.jsonl")
+    record = {
+        "umie_path": umie_path,
+        "dataset_name": "synthetic",
+        "dataset_uid": "99",
+        "phase_name": "CT",
+        "comparative": "",
+        "study_id": "1",
+        "umie_id": umie_id,
+        "mask_path": "",
+        "labels": [],
+        "source_labels": [],
+    }
+    with jsonlines.open(jsonl_path, mode="w") as writer:
+        writer.write(record)
+    return jsonl_path, umie_path
+
+
+def _read_records(jsonl_path: str) -> list:
+    """Read all JSONL records from a path."""
+    with jsonlines.open(jsonl_path, mode="r") as reader:
+        return list(reader)
+
+
+def test_requested_non_phi_fields_written_phi_omitted():
+    """Requested technical tags appear in the JSONL; the PHI tag (PatientName) never does."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path, umie_path = _setup_dataset(tmp)
+        ctx = _make_ctx(tmp)
+        ctx.metadata.dicom_tags = ["PatientSex", "SliceThickness", "KVP", "PatientName"]
+
+        ExtractDicomMetadata(ctx).transform([umie_path])
+
+        records = _read_records(jsonl_path)
+        assert len(records) == 1
+        meta = records[0]["dicom_metadata"]
+        assert meta["PatientSex"] == "F"
+        assert str(meta["SliceThickness"]) == "1.5"
+        assert "KVP" in meta
+        assert "PatientName" not in meta  # PHI denylist enforced even though requested
+
+
+def test_date_tag_is_shifted_not_verbatim():
+    """A requested date tag is shifted (not stored verbatim) and records the offset."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path, umie_path = _setup_dataset(tmp)
+        ctx = _make_ctx(tmp)
+        ctx.metadata.dicom_tags = ["StudyDate"]
+
+        ExtractDicomMetadata(ctx).transform([umie_path])
+
+        meta = _read_records(jsonl_path)[0]["dicom_metadata"]
+        assert "StudyDate" in meta
+        assert meta["StudyDate"] != "20200115"  # de-identified by a deterministic shift
+        assert "StudyDate_offset_days" in meta
+
+
+def test_sidecar_mode_leaves_jsonl_untouched():
+    """With metadata_sidecar, the JSONL is unchanged and a sidecar json is written."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path, umie_path = _setup_dataset(tmp)
+        ctx = _make_ctx(tmp)
+        ctx.metadata.dicom_tags = ["PatientSex"]
+        ctx.metadata.metadata_sidecar = True
+
+        ExtractDicomMetadata(ctx).transform([umie_path])
+
+        assert "dicom_metadata" not in _read_records(jsonl_path)[0]
+        sidecar = os.path.join(tmp, "99_synthetic", "reports", "dicom_metadata.json")
+        data = json.load(open(sidecar))
+        assert data[umie_path]["PatientSex"] == "F"
+
+
+def test_noop_when_no_tags_configured():
+    """When dicom_tags is None the step is a no-op and adds nothing to the JSONL."""
+    with tempfile.TemporaryDirectory() as tmp:
+        jsonl_path, umie_path = _setup_dataset(tmp)
+        ctx = _make_ctx(tmp)  # dicom_tags defaults to None
+
+        returned = ExtractDicomMetadata(ctx).transform([umie_path])
+        assert returned == [umie_path]
+        assert "dicom_metadata" not in _read_records(jsonl_path)[0]

--- a/testing/tests/test_merge_masks.py
+++ b/testing/tests/test_merge_masks.py
@@ -1,0 +1,117 @@
+"""Unit tests for MergeMasks using small synthetic single-structure masks (no external data)."""
+
+import json
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.merge_masks import MergeMasks
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def test_merge_non_overlapping_combines_colors():
+    """Two non-overlapping masks combine into one mask with both colours, overlap_count==0."""
+    mask_a = np.zeros((10, 10), dtype=np.uint8)
+    mask_a[0:3, 0:3] = 1
+    mask_b = np.zeros((10, 10), dtype=np.uint8)
+    mask_b[6:9, 6:9] = 2
+
+    merged, overlap = MergeMasks._merge([mask_a, mask_b], "report", None)
+    assert overlap == 0
+    assert merged[1, 1] == 1
+    assert merged[7, 7] == 2
+    assert set(np.unique(merged).tolist()) == {0, 1, 2}
+
+
+def test_merge_overlap_first_keeps_earlier():
+    """With policy 'first' an overlapping pixel keeps the earlier mask's colour."""
+    mask_a = np.zeros((10, 10), dtype=np.uint8)
+    mask_a[0:5, 0:5] = 1
+    mask_b = np.zeros((10, 10), dtype=np.uint8)
+    mask_b[3:8, 3:8] = 2
+
+    merged, overlap = MergeMasks._merge([mask_a, mask_b], "first", None)
+    assert overlap == 4  # the 2x2 intersection [3:5, 3:5]
+    assert merged[4, 4] == 1  # overlap kept the earlier colour
+    assert merged[1, 1] == 1
+    assert merged[6, 6] == 2
+
+
+def test_merge_overlap_last_keeps_later():
+    """With policy 'last' an overlapping pixel keeps the later mask's colour."""
+    mask_a = np.zeros((10, 10), dtype=np.uint8)
+    mask_a[0:5, 0:5] = 1
+    mask_b = np.zeros((10, 10), dtype=np.uint8)
+    mask_b[3:8, 3:8] = 2
+
+    merged, overlap = MergeMasks._merge([mask_a, mask_b], "last", None)
+    assert overlap == 4
+    assert merged[4, 4] == 2  # overlap kept the later colour
+    assert merged[1, 1] == 1
+    assert merged[6, 6] == 2
+
+
+def test_merge_overlap_priority_keeps_higher_priority():
+    """With policy 'priority' an overlapping pixel keeps the higher-priority colour."""
+    mask_a = np.zeros((10, 10), dtype=np.uint8)
+    mask_a[0:5, 0:5] = 1
+    mask_b = np.zeros((10, 10), dtype=np.uint8)
+    mask_b[3:8, 3:8] = 2
+
+    # colour 2 is listed first -> higher priority than colour 1.
+    merged, overlap = MergeMasks._merge([mask_a, mask_b], "priority", [2, 1])
+    assert overlap == 4
+    assert merged[4, 4] == 2  # higher-priority colour wins regardless of order
+    assert merged[1, 1] == 1
+    assert merged[6, 6] == 2
+
+    # reversing the priority makes colour 1 win the overlap.
+    merged2, _ = MergeMasks._merge([mask_a, mask_b], "priority", [1, 2])
+    assert merged2[4, 4] == 1
+
+
+def test_transform_writes_report_and_merged_masks():
+    """transform merges grouped masks on disk and writes the overlaps summary report."""
+    with tempfile.TemporaryDirectory() as tmp:
+        masks_dir = os.path.join(tmp, "99_synthetic", "CT", "Masks")
+        os.makedirs(masks_dir, exist_ok=True)
+
+        mask_a = np.zeros((10, 10), dtype=np.uint8)
+        mask_a[0:3, 0:3] = 1
+        mask_b = np.zeros((10, 10), dtype=np.uint8)
+        mask_b[6:9, 6:9] = 2
+        # Same UMIE id under sibling structure subfolders so they group together.
+        os.makedirs(os.path.join(masks_dir, "Kidney"), exist_ok=True)
+        os.makedirs(os.path.join(masks_dir, "Neoplasm"), exist_ok=True)
+        path_a = os.path.join(masks_dir, "Kidney", "99_0_001_img.png")
+        path_b = os.path.join(masks_dir, "Neoplasm", "99_0_001_img.png")
+        cv2.imwrite(path_a, mask_a)
+        cv2.imwrite(path_b, mask_b)
+
+        returned = MergeMasks(_make_ctx(tmp)).transform(["unused"])
+        assert returned == ["unused"]
+
+        merged = cv2.imread(path_a, cv2.IMREAD_GRAYSCALE)
+        assert set(np.unique(merged).tolist()) == {0, 1, 2}
+
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "mask_merge_report.json")))
+        assert report["overlap_policy"] == "report"
+        assert len(report["groups"]) == 1
+        assert report["groups"][0]["overlap_pixel_count"] == 0

--- a/testing/tests/test_normalize_spacing.py
+++ b/testing/tests/test_normalize_spacing.py
@@ -1,0 +1,87 @@
+"""Unit tests for the NormalizeSpacing step using small synthetic NIfTI volumes (no external data)."""
+
+import os
+import tempfile
+
+import nibabel as nib
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from constants import OutputMode
+from src.steps.normalize_spacing import NormalizeSpacing
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a 3D-mode PipelineContext rooted at ``tmp`` (synthetic dataset uid 99)."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp, output_mode=OutputMode.VOLUMES_3D),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _save_volume(path: str, data: np.ndarray, spacing: tuple) -> None:
+    """Save ``data`` with a diagonal affine encoding ``spacing`` (one value per spatial axis)."""
+    affine = np.diag([spacing[0], spacing[1], spacing[2], 1.0])
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    nib.save(nib.Nifti1Image(data, affine=affine), path)
+
+
+def test_image_volume_resampled_to_target_spacing():
+    """A (1,1,3) image -> target (1,1,1): header zooms become target and shape scales by 3 on z."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image_path = os.path.join(tmp, "99_synthetic", "CT", "Images", "99_0_001_x.nii.gz")
+        data = np.arange(4 * 4 * 4, dtype=np.float32).reshape(4, 4, 4)
+        _save_volume(image_path, data, spacing=(1.0, 1.0, 3.0))
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.target_spacing_mm = (1.0, 1.0, 1.0)
+        NormalizeSpacing(ctx).transform([image_path])
+
+        out = nib.load(image_path)
+        np.testing.assert_allclose(out.header.get_zooms()[:3], (1.0, 1.0, 1.0), atol=1e-5)
+        # z axis spacing 3 -> 1 means roughly 3x more slices; x/y unchanged.
+        assert out.shape[0] == 4 and out.shape[1] == 4
+        assert out.shape[2] == 12
+
+
+def test_mask_volume_nearest_introduces_no_new_labels():
+    """A mask resampled with order=0 keeps its discrete label set (no interpolation)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        mask_path = os.path.join(tmp, "99_synthetic", "CT", "Masks", "99_0_001_x.nii.gz")
+        labels = np.zeros((4, 4, 4), dtype=np.int16)
+        labels[1:3, 1:3, 0:2] = 2
+        labels[0, 0, 2:4] = 5
+        source_values = set(np.unique(labels).tolist())
+        _save_volume(mask_path, labels, spacing=(1.0, 1.0, 3.0))
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.target_spacing_mm = (1.0, 1.0, 1.0)
+        NormalizeSpacing(ctx).transform([])
+
+        out = nib.load(mask_path)
+        out_values = set(np.unique(out.get_fdata().astype(np.int16)).tolist())
+        assert out_values.issubset(source_values)
+        np.testing.assert_allclose(out.header.get_zooms()[:3], (1.0, 1.0, 1.0), atol=1e-5)
+
+
+def test_no_op_when_target_spacing_none():
+    """With target_spacing_mm unset the volume is left untouched."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image_path = os.path.join(tmp, "99_synthetic", "CT", "Images", "99_0_001_x.nii.gz")
+        data = np.arange(2 * 2 * 2, dtype=np.float32).reshape(2, 2, 2)
+        _save_volume(image_path, data, spacing=(1.0, 1.0, 3.0))
+
+        ctx = _make_ctx(tmp)
+        assert ctx.preprocessing.target_spacing_mm is None
+        NormalizeSpacing(ctx).transform([image_path])
+
+        out = nib.load(image_path)
+        assert out.shape == (2, 2, 2)
+        np.testing.assert_allclose(out.header.get_zooms()[:3], (1.0, 1.0, 3.0), atol=1e-5)

--- a/testing/tests/test_parallel.py
+++ b/testing/tests/test_parallel.py
@@ -1,0 +1,27 @@
+"""Unit tests for process_in_parallel: deterministic, order-preserving results."""
+
+from utils.parallel import process_in_parallel
+
+
+def _square(value: int) -> int:
+    """Return ``value`` squared (a top-level, picklable worker for the process pool)."""
+    return value * value
+
+
+def test_sequential_and_parallel_results_match_and_are_ordered():
+    """num_workers=1 and num_workers=4 give identical, input-ordered results."""
+    items = list(range(20))
+    expected = [v * v for v in items]
+
+    sequential = process_in_parallel(_square, items, num_workers=1)
+    parallel = process_in_parallel(_square, items, num_workers=4)
+
+    assert sequential == expected
+    assert parallel == expected
+    assert parallel == sequential
+
+
+def test_empty_input_returns_empty():
+    """An empty item list returns an empty result for any worker count."""
+    assert process_in_parallel(_square, [], num_workers=1) == []
+    assert process_in_parallel(_square, [], num_workers=4) == []

--- a/testing/tests/test_resize_images.py
+++ b/testing/tests/test_resize_images.py
@@ -1,0 +1,78 @@
+"""Unit tests for the ResizeImages step using small synthetic PNGs (no external data)."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+import pytest
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.resize_images import ResizeImages
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext rooted at ``tmp`` (synthetic dataset uid 99)."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_dataset(tmp: str, image: np.ndarray, mask: np.ndarray) -> tuple[str, str]:
+    """Write a synthetic image+mask pair into the UMIE folder layout; return their paths."""
+    image_dir = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    mask_dir = os.path.join(tmp, "99_synthetic", "CT", "Masks")
+    os.makedirs(image_dir, exist_ok=True)
+    os.makedirs(mask_dir, exist_ok=True)
+    image_path = os.path.join(image_dir, "99_0_001_x.png")
+    mask_path = os.path.join(mask_dir, "99_0_001_x.png")
+    cv2.imwrite(image_path, image)
+    cv2.imwrite(mask_path, mask)
+    return image_path, mask_path
+
+
+@pytest.mark.parametrize("strategy", ["pad", "crop", "letterbox", "stretch"])
+def test_strategy_outputs_target_size_and_preserves_mask_labels(strategy: str):
+    """Each strategy yields target_size for image and mask; mask gains no new label values."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # Non-square 40x80 input (h x w); mask carries discrete labels.
+        image = np.random.randint(0, 256, size=(40, 80), dtype=np.uint8)
+        mask = np.zeros((40, 80), dtype=np.uint8)
+        mask[10:30, 20:60] = 4
+        mask[0:5, 0:5] = 7
+        source_labels = set(np.unique(mask).tolist())
+        image_path, mask_path = _write_dataset(tmp, image, mask)
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.target_size = (32, 32)
+        ctx.preprocessing.resize_strategy = strategy
+        ResizeImages(ctx).transform([image_path])
+
+        out_image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        out_mask = cv2.imread(mask_path, cv2.IMREAD_UNCHANGED)
+        assert out_image.shape == (32, 32)
+        assert out_mask.shape == (32, 32)
+        out_labels = set(np.unique(out_mask).tolist())
+        assert out_labels.issubset(source_labels)
+
+
+def test_no_op_when_target_size_none():
+    """With target_size unset the image is left byte-identical."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image = np.random.randint(0, 256, size=(40, 80), dtype=np.uint8)
+        image_path, _ = _write_dataset(tmp, image, np.zeros((40, 80), dtype=np.uint8))
+        before = open(image_path, "rb").read()
+
+        ctx = _make_ctx(tmp)
+        assert ctx.preprocessing.target_size is None
+        ResizeImages(ctx).transform([image_path])
+
+        assert open(image_path, "rb").read() == before

--- a/testing/tests/test_skip_processed.py
+++ b/testing/tests/test_skip_processed.py
@@ -1,0 +1,82 @@
+"""Unit tests for SkipProcessed: resume filtering and the force_reprocess override."""
+
+import os
+import tempfile
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.skip_processed import SkipProcessed
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _make_source(tmp: str, name: str) -> str:
+    """Create a synthetic source file and return its path."""
+    src = os.path.join(tmp, "source", name)
+    os.makedirs(os.path.dirname(src), exist_ok=True)
+    with open(src, "wb") as handle:
+        handle.write(b"src")
+    return src
+
+
+def _precreate_output(step: SkipProcessed, src: str, data: bytes = b"out") -> str:
+    """Pre-create the UMIE output for ``src`` exactly where the step expects it."""
+    out = step.get_umie_img_path(src)
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "wb") as handle:
+        handle.write(data)
+    return out
+
+
+def test_only_unprocessed_sources_returned():
+    """Sources whose UMIE output already exists are dropped; the rest pass through."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        step = SkipProcessed(ctx)
+
+        done = _make_source(tmp, "done.png")
+        todo = _make_source(tmp, "todo.png")
+
+        # Pre-create the output only for `done` (verifying the path the step expects).
+        _precreate_output(step, done)
+
+        result = step.transform([done, todo])
+        assert result == [todo]
+
+
+def test_zero_byte_output_treated_as_unprocessed():
+    """A zero-byte output (truncated write) does not count as processed."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        step = SkipProcessed(ctx)
+
+        src = _make_source(tmp, "trunc.png")
+        _precreate_output(step, src, data=b"")  # empty file
+
+        assert step.transform([src]) == [src]
+
+
+def test_force_reprocess_returns_all():
+    """With force_reprocess set, every source is returned even if outputs exist."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = _make_ctx(tmp)
+        step = SkipProcessed(ctx)
+
+        done = _make_source(tmp, "done.png")
+        todo = _make_source(tmp, "todo.png")
+        _precreate_output(step, done)
+
+        ctx.export.force_reprocess = True
+        assert SkipProcessed(ctx).transform([done, todo]) == [done, todo]

--- a/testing/tests/test_standardize_bit_depth.py
+++ b/testing/tests/test_standardize_bit_depth.py
@@ -1,0 +1,64 @@
+"""Unit tests for the StandardizeBitDepth step using small synthetic PNGs (no external data)."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.standardize_bit_depth import StandardizeBitDepth
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext rooted at ``tmp`` (synthetic dataset uid 99)."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_image(tmp: str, image: np.ndarray) -> str:
+    """Write a synthetic image into the UMIE folder layout and return its path."""
+    image_dir = os.path.join(tmp, "99_synthetic", "CT", "Images")
+    os.makedirs(image_dir, exist_ok=True)
+    image_path = os.path.join(image_dir, "99_0_001_x.png")
+    cv2.imwrite(image_path, image)
+    return image_path
+
+
+def test_16bit_to_8bit_scaling_no_overflow():
+    """16->8 divides by 256: dtype becomes uint8 and values map with no wraparound."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # Include the max 16-bit value to catch any overflow/wraparound.
+        values = np.array([[0, 256, 512, 65535]], dtype=np.uint16)
+        image_path = _write_image(tmp, values)
+
+        ctx = _make_ctx(tmp)
+        ctx.preprocessing.target_bit_depth = 8
+        StandardizeBitDepth(ctx).transform([image_path])
+
+        out = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+        assert out.dtype == np.uint8
+        # 0//256=0, 256//256=1, 512//256=2, 65535//256=255 (no wraparound to 0).
+        np.testing.assert_array_equal(out.reshape(-1), np.array([0, 1, 2, 255], dtype=np.uint8))
+
+
+def test_no_op_when_target_none():
+    """With target_bit_depth unset the image is left byte-identical."""
+    with tempfile.TemporaryDirectory() as tmp:
+        image_path = _write_image(tmp, np.array([[1, 2, 3, 4]], dtype=np.uint16))
+        before = open(image_path, "rb").read()
+
+        ctx = _make_ctx(tmp)
+        assert ctx.preprocessing.target_bit_depth is None
+        StandardizeBitDepth(ctx).transform([image_path])
+
+        assert open(image_path, "rb").read() == before

--- a/testing/tests/test_validate_dicom_metadata.py
+++ b/testing/tests/test_validate_dicom_metadata.py
@@ -1,0 +1,106 @@
+"""Unit tests for ValidateDicomMetadata using tiny synthetic DICOMs (no external data)."""
+
+import json
+import os
+import tempfile
+
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import CTImageStorage, ExplicitVRLittleEndian, generate_uid
+
+from base.pipeline import PathArgs, PipelineArgs, PipelineContext
+from config.dataset_config import DatasetArgs
+from src.steps.validate_dicom_metadata import ValidateDicomMetadata
+
+
+def _make_ctx(tmp: str) -> PipelineContext:
+    """Build a minimal PipelineContext for the step."""
+    pa = PipelineArgs()
+    identity, dicom, file_selection, output = pa.to_configs()
+    return PipelineContext(
+        paths=PathArgs(source_path=tmp, target_path=tmp),
+        dataset=DatasetArgs(dataset_uid="99", dataset_name="synthetic", phases={"0": "CT"}),
+        identity=identity,
+        dicom=dicom,
+        file_selection=file_selection,
+        output=output,
+    )
+
+
+def _write_dicom(path: str, include_body_part: bool = True) -> None:
+    """Write a tiny DICOM, optionally omitting the BodyPartExamined tag."""
+    meta = FileMetaDataset()
+    meta.MediaStorageSOPClassUID = CTImageStorage
+    meta.MediaStorageSOPInstanceUID = generate_uid()
+    meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds = FileDataset(path, {}, file_meta=meta, preamble=b"\0" * 128)
+    ds.SOPClassUID = CTImageStorage
+    ds.SOPInstanceUID = meta.MediaStorageSOPInstanceUID
+    ds.Modality = "CT"
+    ds.PixelSpacing = [1.0, 1.0]
+    if include_body_part:
+        ds.BodyPartExamined = "CHEST"
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+    ds.save_as(path)
+
+
+def test_missing_tag_reported_and_not_dropped_by_default():
+    """A file missing a required tag is reported, but X is unchanged when not excluding."""
+    with tempfile.TemporaryDirectory() as tmp:
+        valid = os.path.join(tmp, "valid.dcm")
+        missing = os.path.join(tmp, "missing.dcm")
+        _write_dicom(valid, include_body_part=True)
+        _write_dicom(missing, include_body_part=False)
+
+        ctx = _make_ctx(tmp)
+        ctx.quality.required_dicom_tags = {"Modality": "CT", "BodyPartExamined": None}
+
+        returned = ValidateDicomMetadata(ctx).transform([valid, missing])
+        assert set(returned) == {valid, missing}  # nothing dropped by default
+
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "dicom_metadata_report.json")))
+        invalid_keys = set(report["invalid"].keys())
+        assert "missing.dcm" in invalid_keys
+        assert "valid.dcm" not in invalid_keys
+
+
+def test_missing_tag_dropped_when_excluding():
+    """With exclude_invalid_dicom set, the invalid file is dropped from the returned list."""
+    with tempfile.TemporaryDirectory() as tmp:
+        valid = os.path.join(tmp, "valid.dcm")
+        missing = os.path.join(tmp, "missing.dcm")
+        _write_dicom(valid, include_body_part=True)
+        _write_dicom(missing, include_body_part=False)
+
+        ctx = _make_ctx(tmp)
+        ctx.quality.required_dicom_tags = {"Modality": "CT", "BodyPartExamined": None}
+        ctx.quality.exclude_invalid_dicom = True
+
+        returned = ValidateDicomMetadata(ctx).transform([valid, missing])
+        assert returned == [valid]
+
+
+def test_unexpected_value_reported():
+    """A required tag with the wrong value is reported as an unexpected value."""
+    with tempfile.TemporaryDirectory() as tmp:
+        valid = os.path.join(tmp, "valid.dcm")
+        _write_dicom(valid, include_body_part=True)
+
+        ctx = _make_ctx(tmp)
+        ctx.quality.required_dicom_tags = {"Modality": "MR"}  # actual is CT
+
+        ValidateDicomMetadata(ctx).transform([valid])
+        report = json.load(open(os.path.join(tmp, "99_synthetic", "reports", "dicom_metadata_report.json")))
+        assert "valid.dcm" in report["invalid"]
+        issues = report["invalid"]["valid.dcm"]
+        assert any(issue["issue"] == "unexpected_value" for issue in issues)
+
+
+def test_noop_when_not_configured():
+    """When no required tags are configured the step is a no-op and returns X unchanged."""
+    with tempfile.TemporaryDirectory() as tmp:
+        valid = os.path.join(tmp, "valid.dcm")
+        _write_dicom(valid, include_body_part=True)
+        returned = ValidateDicomMetadata(_make_ctx(tmp)).transform([valid])
+        assert returned == [valid]
+        assert not os.path.exists(os.path.join(tmp, "99_synthetic", "reports", "dicom_metadata_report.json"))

--- a/utils/data_counter.py
+++ b/utils/data_counter.py
@@ -9,9 +9,7 @@ import numpy as np
 
 from config.dataset_config import all_datasets
 from config.labels import all_labels
-from config.masks import (  # type: ignore[attr-defined]  # stale util: config.masks has no all_masks (pending Task 22 rework)
-    all_masks,
-)
+from config.masks import all_masks
 from src.constants import TARGET_PATH
 
 
@@ -49,8 +47,8 @@ def calculate_labels_and_mask_ratios() -> None:
     all_imgs_count = 0
     for label in all_labels:
         label_counts[label.radlex_name] = 0
-    for mask in all_masks:
-        mask_counts[mask.radlex_name] = 0
+    for mask_def in all_masks:
+        mask_counts[mask_def.radlex_name] = 0
     for dataset in all_datasets:
         print(f"Checking {dataset.dataset_name}...")
         name_with_id = dataset.dataset_uid + "_" + dataset.dataset_name
@@ -67,12 +65,12 @@ def calculate_labels_and_mask_ratios() -> None:
                         label_counts[label] += 1  # type: ignore[index]
                 if obj["mask_path"]:
                     mask_path = os.path.join(TARGET_PATH, obj["mask_path"])
-                    mask = cv2.imread(mask_path)
-                    for color in list(np.unique(mask)):
+                    mask_img = cv2.imread(mask_path)
+                    for color in list(np.unique(mask_img)):
                         if color != 0:
-                            for mask in all_masks:
-                                if mask.color == color:
-                                    mask_counts[mask.radlex_name] += 1
+                            for mask_def in all_masks:
+                                if mask_def.color == color:
+                                    mask_counts[mask_def.radlex_name] += 1
                 all_imgs_count += 1
 
     print(f"Total images: {all_imgs_count}")
@@ -80,8 +78,8 @@ def calculate_labels_and_mask_ratios() -> None:
     for label in label_counts:  # type: ignore[assignment]
         print(f"{label}: {label_counts[label]}")  # type: ignore[index]
     print("Masks:")
-    for mask in mask_counts:
-        print(f"{mask}: {mask_counts[mask]}")
+    for mask_name in mask_counts:
+        print(f"{mask_name}: {mask_counts[mask_name]}")
     counts = {"label_counts": label_counts, "mask_counts": mask_counts, "all_imgs_count": all_imgs_count}
     with open("data/counts.json", "w") as f:
         json.dump(counts, f)

--- a/utils/distribution_report.py
+++ b/utils/distribution_report.py
@@ -1,0 +1,305 @@
+"""Dataset distribution report over the processed UMIE JSONL files (Task 22).
+
+This is a standalone *utility* (not a pipeline step). Given a ``data_dir`` containing one or
+more processed datasets, each laid out as ``{data_dir}/{uid}_{name}/{uid}_{name}.jsonl``, it
+reads every dataset JSONL and computes:
+
+- per-dataset and global label frequencies (labels are lists of ``{radlex_name: grade}`` dicts),
+- a modality breakdown by ``phase_name``,
+- per-dataset class-imbalance ratios (``max_count / min_count`` over that dataset's labels),
+- a segmentation-mask size distribution (nonzero-pixel counts per mask) for masks that exist
+  and are readable with OpenCV.
+
+It writes a markdown report and a CSV next to ``output_path`` (defaulting to
+``data_dir/distribution_report.md`` and ``.../distribution_report.csv``) and returns the
+computed stats dict so it is directly unit-testable without asserting on files on disk.
+
+Robustness: missing or unreadable JSONL / mask files are skipped, never crash the run, and the
+function never reprocesses images beyond reading mask pixel arrays.
+"""
+
+from __future__ import annotations
+
+import csv
+import glob
+import json
+import os
+from collections import Counter
+from typing import Any, Optional
+
+import cv2  # type: ignore[import-untyped]
+import numpy as np
+
+
+def generate_distribution_report(data_dir: str, output_path: Optional[str] = None) -> dict:
+    """Compute label / modality / imbalance / mask-size distributions over a data dir.
+
+    Args:
+        data_dir (str): Directory containing ``{uid}_{name}/{uid}_{name}.jsonl`` datasets.
+        output_path (Optional[str]): Base path for the markdown report; the CSV is written
+            alongside with a ``.csv`` extension. Defaults to ``data_dir/distribution_report.md``.
+    Returns:
+        dict: The computed statistics (per-dataset + global label counts, modality breakdown,
+        class-imbalance ratios, and mask-size distribution).
+    """
+    per_dataset: dict[str, dict[str, Any]] = {}
+    global_labels: Counter = Counter()
+    global_modalities: Counter = Counter()
+    global_mask_sizes: list[int] = []
+    total_records = 0
+
+    for jsonl_path in _find_dataset_jsonls(data_dir):
+        dataset_key = os.path.basename(os.path.dirname(jsonl_path))
+        records = _read_jsonl(jsonl_path)
+        total_records += len(records)
+
+        labels = _count_labels(records)
+        modalities = _count_modalities(records)
+        mask_sizes = _mask_sizes(records, data_dir)
+
+        global_labels.update(labels)
+        global_modalities.update(modalities)
+        global_mask_sizes.extend(mask_sizes)
+
+        per_dataset[dataset_key] = {
+            "num_records": len(records),
+            "label_counts": dict(labels),
+            "modality_counts": dict(modalities),
+            "class_imbalance_ratio": _imbalance_ratio(labels),
+            "mask_size_distribution": _summarize_sizes(mask_sizes),
+        }
+
+    stats: dict[str, Any] = {
+        "data_dir": data_dir,
+        "num_datasets": len(per_dataset),
+        "total_records": total_records,
+        "per_dataset": per_dataset,
+        "global": {
+            "label_counts": dict(global_labels),
+            "modality_counts": dict(global_modalities),
+            "class_imbalance_ratio": _imbalance_ratio(global_labels),
+            "mask_size_distribution": _summarize_sizes(global_mask_sizes),
+        },
+    }
+
+    md_path = output_path or os.path.join(data_dir, "distribution_report.md")
+    csv_path = os.path.splitext(md_path)[0] + ".csv"
+    try:
+        _write_markdown(stats, md_path)
+        _write_csv(stats, csv_path)
+    except OSError:
+        # Writing reports is best-effort; never let an unwritable path break the computation.
+        pass
+
+    return stats
+
+
+def _find_dataset_jsonls(data_dir: str) -> list[str]:
+    """Find every ``{uid}_{name}/{uid}_{name}.jsonl`` under ``data_dir``.
+
+    Args:
+        data_dir (str): Root data directory.
+    Returns:
+        list[str]: Sorted list of dataset JSONL paths whose name matches their folder.
+    """
+    found: list[str] = []
+    for jsonl_path in sorted(glob.glob(os.path.join(data_dir, "*", "*.jsonl"))):
+        folder = os.path.basename(os.path.dirname(jsonl_path))
+        if os.path.basename(jsonl_path) == f"{folder}.jsonl":
+            found.append(jsonl_path)
+    return found
+
+
+def _read_jsonl(path: str) -> list[dict]:
+    """Read a JSONL file into a list of records, skipping unreadable files / lines.
+
+    Args:
+        path (str): Path to the JSONL file.
+    Returns:
+        list[dict]: Parsed records (empty when the file is missing or unreadable).
+    """
+    records: list[dict] = []
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return []
+    return records
+
+
+def _count_labels(records: list[dict]) -> Counter:
+    """Count RadLex label occurrences across records.
+
+    ``labels`` is a list of ``{radlex_name: grade}`` dicts; each radlex name counts once per
+    record it appears on.
+
+    Args:
+        records (list[dict]): Dataset records.
+    Returns:
+        Counter: ``{radlex_name: count}``.
+    """
+    counter: Counter = Counter()
+    for record in records:
+        for label in record.get("labels", []) or []:
+            if isinstance(label, dict):
+                for radlex_name in label.keys():
+                    counter[str(radlex_name)] += 1
+    return counter
+
+
+def _count_modalities(records: list[dict]) -> Counter:
+    """Count modality occurrences by ``phase_name``.
+
+    Args:
+        records (list[dict]): Dataset records.
+    Returns:
+        Counter: ``{phase_name: count}``.
+    """
+    counter: Counter = Counter()
+    for record in records:
+        phase_name = record.get("phase_name")
+        if phase_name:
+            counter[str(phase_name)] += 1
+    return counter
+
+
+def _imbalance_ratio(counts: Counter) -> Optional[float]:
+    """Compute the class-imbalance ratio (max_count / min_count) over label counts.
+
+    Args:
+        counts (Counter): Label counts.
+    Returns:
+        Optional[float]: The ratio, or ``None`` when fewer than two labels are present.
+    """
+    values = [value for value in counts.values() if value > 0]
+    if len(values) < 2:
+        return None
+    return round(max(values) / min(values), 4)
+
+
+def _mask_sizes(records: list[dict], data_dir: str) -> list[int]:
+    """Read nonzero-pixel counts for each record's mask, when the mask exists and is readable.
+
+    Args:
+        records (list[dict]): Dataset records.
+        data_dir (str): Root data dir, used to resolve relative ``mask_path`` values.
+    Returns:
+        list[int]: Nonzero-pixel counts (one per readable mask).
+    """
+    sizes: list[int] = []
+    for record in records:
+        mask_path = record.get("mask_path")
+        if not mask_path:
+            continue
+        resolved = mask_path if os.path.isabs(mask_path) else os.path.join(data_dir, mask_path)
+        if not os.path.exists(resolved):
+            continue
+        try:
+            mask = cv2.imread(resolved, cv2.IMREAD_UNCHANGED)
+        except Exception:
+            continue
+        if mask is None:
+            continue
+        sizes.append(int(np.count_nonzero(mask)))
+    return sizes
+
+
+def _summarize_sizes(sizes: list[int]) -> dict[str, Any]:
+    """Summarise a list of nonzero-pixel counts.
+
+    Args:
+        sizes (list[int]): Nonzero-pixel counts.
+    Returns:
+        dict[str, Any]: ``count`` plus ``min`` / ``max`` / ``mean`` / ``median`` (None when empty).
+    """
+    if not sizes:
+        return {"count": 0, "min": None, "max": None, "mean": None, "median": None}
+    array = np.asarray(sizes, dtype=float)
+    return {
+        "count": len(sizes),
+        "min": int(array.min()),
+        "max": int(array.max()),
+        "mean": round(float(array.mean()), 2),
+        "median": round(float(np.median(array)), 2),
+    }
+
+
+def _write_markdown(stats: dict, path: str) -> None:
+    """Write the human-readable markdown distribution report.
+
+    Args:
+        stats (dict): The computed statistics.
+        path (str): Destination markdown path.
+    """
+    lines: list[str] = []
+    lines.append("# Dataset Distribution Report")
+    lines.append("")
+    lines.append(f"- Data dir: `{stats['data_dir']}`")
+    lines.append(f"- Datasets: {stats['num_datasets']}")
+    lines.append(f"- Total records: {stats['total_records']}")
+    lines.append("")
+
+    lines.append("## Global label frequencies")
+    lines.append("")
+    lines.append("| RadLex label | Count |")
+    lines.append("| --- | --- |")
+    for name, count in sorted(stats["global"]["label_counts"].items(), key=lambda item: -item[1]):
+        lines.append(f"| {name} | {count} |")
+    lines.append("")
+
+    lines.append("## Global modality breakdown (by phase_name)")
+    lines.append("")
+    lines.append("| Modality | Count |")
+    lines.append("| --- | --- |")
+    for name, count in sorted(stats["global"]["modality_counts"].items(), key=lambda item: -item[1]):
+        lines.append(f"| {name} | {count} |")
+    lines.append("")
+    lines.append(f"Global class-imbalance ratio: {stats['global']['class_imbalance_ratio']}")
+    lines.append(f"Global mask-size distribution: {stats['global']['mask_size_distribution']}")
+    lines.append("")
+
+    lines.append("## Per-dataset")
+    lines.append("")
+    for dataset_key, info in sorted(stats["per_dataset"].items()):
+        lines.append(f"### {dataset_key}")
+        lines.append("")
+        lines.append(f"- Records: {info['num_records']}")
+        lines.append(f"- Class-imbalance ratio: {info['class_imbalance_ratio']}")
+        lines.append(f"- Label counts: {info['label_counts']}")
+        lines.append(f"- Modality counts: {info['modality_counts']}")
+        lines.append(f"- Mask-size distribution: {info['mask_size_distribution']}")
+        lines.append("")
+
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+
+
+def _write_csv(stats: dict, path: str) -> None:
+    """Write a flat per-dataset, per-label CSV alongside the markdown report.
+
+    Args:
+        stats (dict): The computed statistics.
+        path (str): Destination CSV path.
+    """
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["scope", "dataset", "metric", "key", "value"])
+        for name, count in sorted(stats["global"]["label_counts"].items()):
+            writer.writerow(["global", "", "label_count", name, count])
+        for name, count in sorted(stats["global"]["modality_counts"].items()):
+            writer.writerow(["global", "", "modality_count", name, count])
+        writer.writerow(["global", "", "class_imbalance_ratio", "", stats["global"]["class_imbalance_ratio"]])
+        for dataset_key, info in sorted(stats["per_dataset"].items()):
+            writer.writerow(["dataset", dataset_key, "num_records", "", info["num_records"]])
+            writer.writerow(["dataset", dataset_key, "class_imbalance_ratio", "", info["class_imbalance_ratio"]])
+            for name, count in sorted(info["label_counts"].items()):
+                writer.writerow(["dataset", dataset_key, "label_count", name, count])
+            for name, count in sorted(info["modality_counts"].items()):
+                writer.writerow(["dataset", dataset_key, "modality_count", name, count])

--- a/utils/parallel.py
+++ b/utils/parallel.py
@@ -1,0 +1,69 @@
+"""Deterministic parallel map helper for the opt-in multiprocessing steps (Theme H, Task 29).
+
+:func:`process_in_parallel` maps a function over a sequence of items, optionally across a
+process pool, while guaranteeing the result order matches the input order regardless of the
+worker count. It is the single concurrency primitive the pipeline steps should use; the
+number of workers is driven by :attr:`base.pipeline.ExportConfig.num_workers`.
+
+Concurrency contract (read before using a worker count > 1):
+    * Worker functions must be *pure*: they take one item and RETURN data. They must not
+      mutate shared state and must not write to the shared JSONL or any shared output file.
+      With a process pool each worker runs in its own process, so concurrent writes to a
+      single JSONL would interleave and clobber records.
+    * The MAIN process owns all serial JSONL / file writes. The intended pattern is to do
+      the CPU-bound, side-effect-free transform in the workers, collect the ordered results
+      here, then have the caller (in the main process) write them out sequentially.
+    * Because results are returned in input order and writes happen serially in the main
+      process, output is byte-identical regardless of ``num_workers``.
+    * Worker functions and their arguments must be picklable (define them at module top
+      level, not as closures/lambdas), as required by :mod:`multiprocessing`.
+
+A wall-clock benchmark on a large real dataset is a follow-up (it needs real data); this
+module only establishes the deterministic, order-preserving contract.
+"""
+
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from multiprocessing import get_context
+from typing import Callable, List, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def process_in_parallel(
+    func: Callable[[T], R],
+    items: Sequence[T],
+    num_workers: int = 1,
+    ordered: bool = True,
+) -> List[R]:
+    """Map ``func`` over ``items``, optionally in parallel, preserving input order.
+
+    When ``num_workers <= 1`` the items are processed sequentially in the current process
+    (no pool is created). When ``num_workers > 1`` a :class:`ProcessPoolExecutor` runs the
+    work across processes; with ``ordered=True`` the returned list is in the same order as
+    ``items`` no matter how many workers are used (deterministic).
+
+    Args:
+        func (Callable[[T], R]): A pure, picklable function applied to each item.
+        items (Sequence[T]): The items to process.
+        num_workers (int): Number of worker processes; ``<= 1`` runs sequentially.
+        ordered (bool): If ``True`` (default), results follow input order.
+
+    Returns:
+        List[R]: The results of applying ``func`` to each item.
+    """
+    item_list = list(items)
+    if num_workers <= 1 or len(item_list) <= 1:
+        return [func(item) for item in item_list]
+
+    # "spawn" avoids the fork()-in-a-multi-threaded-process deadlock risk (and the matching
+    # DeprecationWarning) that bites the default fork start method on Linux.
+    with ProcessPoolExecutor(max_workers=num_workers, mp_context=get_context("spawn")) as executor:
+        if ordered:
+            # Executor.map yields results in submission (input) order, giving deterministic
+            # output regardless of which worker finishes first.
+            return list(executor.map(func, item_list))
+        # Unordered: return results as they complete (faster, but order is non-deterministic;
+        # only use when the caller does not rely on positional correspondence with `items`).
+        futures = [executor.submit(func, item) for item in item_list]
+        return [future.result() for future in as_completed(futures)]


### PR DESCRIPTION
## Purpose

Implement **Group 1, Themes D–I (Tasks 10–30)** from `UMIE notes/tasks/UMIE_datasets_tasks.md` — the data-quality, preprocessing, metadata-enrichment, additional-format, infrastructure, and downstream-export work that builds on the Tasks 1–9 foundation (uv build, `PipelineContext`/config refactor, optional 3D output).

## Why this is needed

The plan ranks **duplicate detection, intensity windowing, patient-level splits, and DICOM-SEG/RTSTRUCT support** among the highest immediate-impact items. These steps unlock dataset auditing, reproducible preprocessing, richer metadata, more source formats, reproducible runs, and a first-class HuggingFace export — all plugged into the existing `BaseStep`/`BasePipeline` extension points rather than parallel machinery.

## Guiding principles honored

- **Additive & opt-in.** Every step is a no-op when unconfigured and is *not* added to any existing pipeline's `steps` tuple, so current behavior is unchanged.
- **No convention changes.** No step alters the UMIE id format, the `{uid}_{name}/{phase}/Images|Masks/` layout, or any existing JSONL field — new fields are additive only.
- **Reuse the extension points.** New work threads through `PipelineArgs` → `PipelineContext` → `BaseStep`.
- **No new dependencies.** Everything is built on already-vendored libs (`cv2`, `numpy`, `nibabel`, `pydicom`, `scipy`, `datasets`, `jsonlines`, `pandas`). `uv.lock` is untouched.

## What changed

**Shared infrastructure**
- New opt-in sub-configs `QualityConfig` / `PreprocessingConfig` / `MetadataConfig` / `FormatConfig` / `ExportConfig`, passed as whole objects on `PipelineArgs` and exposed on `PipelineContext` + `BaseStep` with safe defaults (existing direct `PipelineContext(...)` constructions keep working).
- `REPORTS_FOLDER_NAME` + `BaseStep.reports_dir()` / `dataset_root` helpers — analysis reports live in a `reports/` folder outside `Images`/`Masks`, so golden file-trees are untouched.
- `config/masks.py` gains `all_masks` (also fixes the stale `config.masks.all_masks` reference in `utils/data_counter.py`); new `config/provenance.py` is the canonical license/attribution table.

**Theme D — data quality & validation** (`quality` config)
- `DetectDuplicates` (Task 10) — dHash duplicate/near-duplicate clustering + cross-dataset overlap; JSON/CSV report; optional additive `duplicate_group_id`; never deletes.
- `DetectCorruptImages` (Task 11) — flags unreadable/truncated/blank/undersized images.
- `CheckMaskQuality` (Task 12) — mask↔image dim match, in-vocabulary colors, empty-mask report.
- `ValidateDicomMetadata` (Task 13) — verifies required DICOM tags *before* conversion; optional exclusion.

**Theme E — preprocessing** (`preprocessing` config; images only, geometry ops also remap masks nearest-neighbour)
- `ApplyWindowing` (14), `ApplyClahe` (15), `NormalizeSpacing` (16), `ResizeImages` (17), `StandardizeBitDepth` (18), `AutocropBorders` (19).

**Theme F — metadata enrichment** (`metadata` config; additive JSONL)
- `ExtractDicomMetadata` (20, de-identified), `CreateSplits` (21, reproducible **patient/study-level** splits), `AddProvenance` (23), and `utils/distribution_report.py` (22, cross-dataset label/modality/imbalance report).

**Theme G — additional formats** (`format_conversion` config → UMIE masks)
- `ConvertDicomSeg` (24, DICOM-SEG + RTSTRUCT), `ConvertBboxToMask` (25, COCO/YOLO/VOC), `MergeMasks` (26).

**Theme H — infrastructure** (`export` config)
- `CreateManifest` (27, SHA-256 manifest + verify mode), `SkipProcessed` (28, incremental resume), `utils/parallel.py` (29, deterministic order-preserving parallel map).

**Theme I — downstream export** (`export` config)
- `ExportHuggingFace` (30) — writes an HF `datasets` Arrow dataset on disk with train/val/test splits (from Task 21), a features schema, and an auto-generated dataset card carrying license/provenance (Task 23). Round-trips via `load_from_disk`.

All 19 steps are registered in `src/steps/__init__.py` and documented in a new README section.

## Testing

- **68 new synthetic-data unit tests, all passing** (no external data required). Full suite: `141 passed`.
- The pre-existing **44 failures require the `umie-tests` S3 golden dummy data** (`testing/download_files.py`) and are **identical before and after** this PR (verified against `main`).
- `ruff check`, `ruff format`, `pydocstyle`, and `mypy` (strict) are clean on every new file. (The only tree-wide mypy errors are 2 pre-existing ones in `src/steps/add_umie_ids.py`, untouched here and only matched by pre-commit on changed files.)

## Follow-ups

- MONAI/nnU-Net and WebDataset/TFRecord exports (extends Task 30).
- Wall-clock parallel benchmark on a large dataset (Task 29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)